### PR TITLE
Support FreeBSD

### DIFF
--- a/package-scripts/chef-server/postinst
+++ b/package-scripts/chef-server/postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Perform necessary chef-server setup steps after package is installed.
 #

--- a/package-scripts/chef-server/postrm
+++ b/package-scripts/chef-server/postrm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # see: http://tickets.opscode.com/browse/CHEF-3022
 if [ ! -e /etc/redhat-release -o "x$1" == "x0" ]; then

--- a/package-scripts/chef/install.sh
+++ b/package-scripts/chef/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This chef-full install script is maintained @

--- a/package-scripts/chef/postinst
+++ b/package-scripts/chef/postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Install a full Opscode Client
 #

--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022


### PR DESCRIPTION
Greetings,

This is a simple change to the package scripts (install.sh, postrm, postinst) that replaces '#!/bin/bash' with '#!/usr/bin/env bash'. The thinking is we can use the exact same scripts in non-linux os packages where bash is not in /bin. I think this would only break very old and/or busted operating systems but I could be wrong there.

Thanks,
Brandon
