### PR TITLE
OC-3474: Add reindex command for Chef Server

### DIFF
--- a/files/chef-server-ctl-commands/reindex.rb
+++ b/files/chef-server-ctl-commands/reindex.rb
@@ -1,0 +1,21 @@
+# Copyright: Copyright (c) 2012 Opscode, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_command "reindex", "Reindex all server data", 1 do
+  command = "complete"
+  Dir.chdir(File.join(base_path, "embedded", "service", "erchef", "bin")) do
+    exec("./reindex-chef-server #{command}")
+  end
+end


### PR DESCRIPTION
Reindexing is now a server-side function, and not exposed through the REST API.
