### PR TITLE
OC-4908: Consolidation of Pedant Repositories

### DIFF
--- a/config/software/chef-pedant.rb
+++ b/config/software/chef-pedant.rb
@@ -16,7 +16,7 @@
 #
 
 name "chef-pedant"
-version "69e7b8400292a249e1058242d02a58c9f92b4d08"
+version "cm/OC-4908"
 
 dependencies ["ruby",
               "bundler",

--- a/files/chef-server-ctl-commands/test.rb
+++ b/files/chef-server-ctl-commands/test.rb
@@ -25,5 +25,5 @@ add_command "test", "Run the API test suite against localhost.", 2 do
   Dir.chdir(File.join(base_path, "embedded", "service", "chef-pedant"))
   pedant_config = File.join(data_path, "chef-pedant", "etc", "pedant_config.rb")
   bundle = File.join(base_path, "embedded", "bin", "bundle")
-  exec("#{bundle} exec ./chef-pedant -c #{pedant_config} #{pedant_args.join(' ')}")
+  exec("#{bundle} exec ./bin/chef-pedant -c #{pedant_config} #{pedant_args.join(' ')}")
 end


### PR DESCRIPTION
Support the use of consolidated `chef-pedant` and `oc-chef-pedant`
repositories.
