### PR TITLE
OC-4709: Add server api version header

### DIFF
--- a/files/chef-server-cookbooks/chef-server/attributes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/attributes/default.rb
@@ -18,7 +18,9 @@
 ###
 # High level options
 ###
-default['chef_server']['version'] = "11.0.0"
+default['chef_server']['api_version'] = "11.0.0"
+default['chef_server']['flavor'] = "osc" # Open Source Chef
+
 default['chef_server']['notification_email'] = "info@example.com"
 default['chef_server']['database_type'] = "postgresql"
 default['chef_server']['bootstrap']['enable'] = true

--- a/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
@@ -17,7 +17,8 @@
                          {file_size, 50}]]}
             ]},
  {chef_wm, [
-              {server_version, "<%= node['chef_server']['version'] %>"},
+              {api_version, "<%= node['chef_server']['api_version'] %>"},
+              {server_flavor, "<%= node['chef_server']['flavor'] %>"},
               {health_ping_modules, [chef_sql, chef_solr]},
               {health_ping_timeout, 400},
               {local_key_gen, {true, 2048}},


### PR DESCRIPTION
This adds an X-Ops-API-Info header to Erchef server responses.

It contains the "flavor" of server (i.e. "osc" or "opc"), the logical
server version (e.g. "11.0.0" for upcoming Chef 11), and the OTP
version of the Erchef release (mainly useful for debugging).

An example:

```
vagrant@open-source-chef:/srv/piab/mounts/erchef$ curl -I 127.0.0.1:8000/nodes
HTTP/1.1 405 Method Not Allowed
X-Ops-API-Info: flavor=osc;version=11.0.0;erchef=1.0.9
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Date: Wed, 21 Nov 2012 02:37:36 GMT
Content-Length: 0
Allow: GET, POST
```

(quick-and-dirty test with an unauthenticated request, but you get the picture.)

This has been confirmed on Omnibus builds of both Erchef servers.
