### PR TITLE
Lockdown perms for /etc/chef-server and pem files

### DIFF
--- a/files/chef-server-cookbooks/chef-server/recipes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/default.rb
@@ -22,7 +22,7 @@ ENV['PATH'] = "/opt/chef-server/bin:/opt/chef-server/embedded/bin:#{ENV['PATH']}
 directory "/etc/chef-server" do
   owner "root"
   group "root"
-  mode "0775"
+  mode "0700"
   action :nothing
 end.run_action(:create)
 
@@ -86,6 +86,6 @@ include_recipe "chef-server::chef-pedant"
 file "/etc/chef-server/chef-server-running.json" do
   owner node['chef_server']['user']['username']
   group "root"
-  mode "0644"
+  mode "0600"
   content Chef::JSONCompat.to_json_pretty({ "chef_server" => node['chef_server'].to_hash, "run_list" => node.run_list })
 end


### PR DESCRIPTION
This resolves CHEF-361.

The permissions on /etc/chef-server are locked down now.
pem files within the directory written via erchef bootstrap are now
written with owner rw only perms.
