### PR TITLE
Fix location of bookshelf logging

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/bookshelf.config.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/bookshelf.config.erb
@@ -22,6 +22,7 @@
                  {keys, {"<%= @access_key_id %>",
                          "<%= @secret_access_key %>"}},
                  {disk_store, "<%= @data_dir %>"},
-                 {stream_download, <%= @stream_download %>}
+                 {stream_download, <%= @stream_download %>},
+                 {log_dir, "<%= @log_directory %>"}
                 ]}
 ].


### PR DESCRIPTION
This fixes CHEF-3640

We were just missing a sys config entry for the log directory. Note
that bookshelf doesn't log much of anything (its own problem).
