### PR TITLE
remove duplicate attribute, use return instead of exit

### DIFF
--- a/files/chef-server-cookbooks/chef-server/attributes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/attributes/default.rb
@@ -114,7 +114,6 @@ default['chef_server']['bookshelf']['secret_access_key'] = "generated-by-default
 # Erlang Chef Server API
 ####
 default['chef_server']['erchef']['enable'] = true
-default['chef_server']['erchef']['enable'] = true
 default['chef_server']['erchef']['ha'] = false
 default['chef_server']['erchef']['dir'] = "/var/opt/chef-server/erchef"
 default['chef_server']['erchef']['log_directory'] = "/var/log/chef-server/erchef"

--- a/files/chef-server-cookbooks/chef-server/recipes/show_config.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/show_config.rb
@@ -22,5 +22,4 @@ end
 config = ChefServer.generate_config(node['fqdn'])
 
 puts Chef::JSONCompat.to_json_pretty(config)
-exit 0
-
+return


### PR DESCRIPTION
- DRY! don't need duplicated default attribute setting
- the show_config recipe errors on 'exit' so use return instead,
  though not having it at all works too.
