### PR TITLE
Convert to new stats_hero supporting custom module config

### DIFF
--- a/files/chef-server-cookbooks/chef-server/attributes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/attributes/default.rb
@@ -135,6 +135,7 @@ default['chef_server']['erchef']['url'] = "http://127.0.0.1:8000"
 default['chef_server']['erchef']['validation_client_name'] = "chef-validator"
 default['chef_server']['erchef']['umask'] = "0022"
 default['chef_server']['erchef']['web_ui_client_name'] = "chef-webui"
+default['chef_server']['erchef']['root_metric_key'] = "chefAPI"
 
 ####
 # Chef Server WebUI

--- a/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
@@ -30,7 +30,9 @@
               %% how many nodes are deserialized at a time in
               %% preparing a response.
               {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
-              {superusers, [<<"chef-webui">>]}
+              {superusers, [<<"chef-webui">>]},
+              %% metrics config
+              {root_metric_key, "<%= @root_metric_key %>"}
              ]},
   {chef_authn, [
                 {keyring, [{default, "/etc/chef-server/chef-webui.pem"}]}


### PR DESCRIPTION
The sf/modular-config branch of stats_hero removes hard-coding of
module names used for metric aggregation along with a few other minor
improvements.

This PR includes the changes required to use the new stats_hero.

A few of the commits will be updated prior to merge since we will
merge stats_hero to master and same for chef_wm.

I built a local deb using omnibus-chef, verified a full pedant
run, and drove some traffic at it to verify that metrics appear in
graphite.
