### PR TITLE
Resolves CHEF-3889

### DIFF
--- a/files/chef-server-cookbooks/chef-server/attributes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/attributes/default.rb
@@ -256,7 +256,16 @@ default['chef_server']['postgresql']['md5_auth_cidr_addresses'] = [ ]
 default['chef_server']['postgresql']['trust_auth_cidr_addresses'] = [ '127.0.0.1/32', '::1/128' ]
 default['chef_server']['postgresql']['shmmax'] = kernel['machine'] =~ /x86_64/ ? 17179869184 : 4294967295
 default['chef_server']['postgresql']['shmall'] = kernel['machine'] =~ /x86_64/ ? 4194304 : 1048575
-default['chef_server']['postgresql']['shared_buffers'] = "#{(node['memory']['total'].to_i / 4) / (1024)}MB"
+
+# Resolves CHEF-3889
+if (node['memory']['total'].to_i / 4) > ((node['chef_server']['postgresql']['shmmax'].to_i / 1024) - 2097152)
+  # guard against setting shared_buffers > shmmax on hosts with installed RAM > 64GB
+  # use 2GB less than shmmax as the default for these large memory machines
+  default['chef_server']['postgresql']['shared_buffers'] = "14336MB"
+else
+  default['chef_server']['postgresql']['shared_buffers'] = "#{(node['memory']['total'].to_i / 4) / (1024)}MB"
+end
+
 default['chef_server']['postgresql']['work_mem'] = "8MB"
 default['chef_server']['postgresql']['effective_cache_size'] = "#{(node['memory']['total'].to_i / 2) / (1024)}MB"
 default['chef_server']['postgresql']['checkpoint_segments'] = 10


### PR DESCRIPTION
On machines with installed RAM > 64GB the postgresql shared_buffers
configuration would exceed shmmax.  This change places a maximum on
shared_pages on machines where Installed RAM / 4 execeds the size of shmmax
of 14GB

This does not solve the case where you have a 32bit installation and more
than 16GB of RAM.
