### PR TITLE
Add back enable_non_ssl for nginx

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
@@ -63,6 +63,7 @@ http {
 
     proxy_set_header Host $host:$server_port;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass_request_headers on;
     proxy_connect_timeout   1;
     proxy_send_timeout      300;
@@ -141,7 +142,7 @@ http {
 
 		client_max_body_size <%= @client_max_body_size %>;
 
-    proxy_set_header Host $host;
+    proxy_set_header Host $host:$server_port;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
enable_non_ssl was removed from the nginx template a while back:
https://github.com/opscode/omnibus-chef/commit/f28779d05fd2e8214d4b50a793462193f242f609#L9L58

This adds it back in, to allow for an ssl balancer in front of chef servers.
