### PR TITLE
make package metadata public

### DIFF
--- a/jenkins/release.rb
+++ b/jenkins/release.rb
@@ -327,6 +327,7 @@ class ShipIt
     s3_cmd = ["s3cmd",
               "-c #{options[:metadata_s3_config_file]}",
               "put",
+              "--acl-public",
               "v2-release-manifest.json",
               s3_location].join(" ")
     shell = Mixlib::ShellOut.new(s3_cmd, shellout_opts)


### PR DESCRIPTION
verification relies on this data being public or else we have to have another IAM account with read access. We make this info public one way or another anyway, so defaulting to public isn't leaking otherwise secret info.
