### PR TITLE
stop `runit_service` supervise/ok race condition

### DIFF
--- a/files/chef-server-cookbooks/runit/definitions/runit_service.rb
+++ b/files/chef-server-cookbooks/runit/definitions/runit_service.rb
@@ -161,7 +161,10 @@ define :runit_service, :directory => nil, :only_if => false, :finish_script => f
     ruby_block "supervise_#{params[:name]}_sleep" do
       block do
         Chef::Log.debug("Waiting until named pipe #{sv_dir_name}/supervise/ok exists.")
-        (1..10).each {|i| sleep 1 unless ::FileTest.pipe?("#{sv_dir_name}/supervise/ok") }
+        until ::FileTest.pipe?("#{sv_dir_name}/supervise/ok") do
+          sleep 1
+          Chef::Log.debug(".")
+        end
       end
       not_if { FileTest.pipe?("#{sv_dir_name}/supervise/ok") }
     end


### PR DESCRIPTION
Currently we wait 10 seconds for a runit service's supervise/ok named 
pipe. On slower systems (_cough_ CentOS 5.x) this 10 second wait is not 
long enough.  This commit updates the embedded runit cookbook that ships 
in omnibus-chef to match the indefinite block used in the current 
version of community cookbook:

https://github.com/opscode-cookbooks/runit/blob/1.1.0/libraries/provider_runit_service.rb#L151-L153

Longer term we need to just pull in a version of this cookbook at 
package build time using a tool like Berkshelf.

^^ @seth @adamhjk 
