### PR TITLE
remove all v1 metadata uploads

### DIFF
--- a/jenkins/release.rb
+++ b/jenkins/release.rb
@@ -285,11 +285,19 @@ class ShipIt
     {:timeout => 1200, :live_stream => STDOUT}
   end
 
+  def progress
+    if STDOUT.tty?
+      "--progress"
+    else
+      "--no-progress"
+    end
+  end
+
   def upload_package(local_path, s3_path)
     s3_cmd = ["s3cmd",
               "-c #{options[:package_s3_config_file]}",
               "put",
-              "--progress",
+              progress,
               "--acl-public",
               local_path,
               "s3://#{options[:bucket]}#{s3_path}"].join(" ")


### PR DESCRIPTION
Removes all v1 metadata uploads, which are no longer needed now that omnitruck 0.4.0 is deployed.
# NOTE

I overlooked a required config change in one of the s3cmd commands when updating this previously. Trying to release a package with the current config settings will trigger this error:

```
---- Begin output of s3cmd put platform-support.json s3://opscode-omnibus-packages-test/chef-platform-support/11.4.1.alpha.1-1.json ----
STDOUT: 
STDERR: ERROR: S3 error: 403 (AccessDenied): Access Denied
---- End output of s3cmd put platform-support.json s3://opscode-omnibus-packages-test/chef-platform-support/11.4.1.alpha.1-1.json ----
```

The problem is that a few of the s3cmd commands try to upload metadata to the bucket that you pass in with the `-b` option but do not pass in the correct s3cmd config file. For example:

https://github.com/opscode/omnibus-chef/blob/dc8613e9a84d57f217e312f16fa647b3a66d8fac/jenkins/release.rb#L323-327

The approach in this pull request simply removes all the old stuff, I'm open to try a different way of doing it if there's reason to do so.
