### PR TITLE
[CHEF-2578] - do not overwrite /usr/bin symlinks

### DIFF
--- a/package-scripts/chef/makeselfinst
+++ b/package-scripts/chef/makeselfinst
@@ -59,13 +59,11 @@ if [ "" != "$validation_key" ]; then
   chmod 600 ${CONFIG_DIR}/validation.pem
 fi
 
-ln -sf $DEST_DIR/bin/chef-client /usr/bin || error_exit "Cannot link chef-client to /usr/bin"
-ln -sf $DEST_DIR/bin/chef-solo /usr/bin || error_exit "Cannot link chef-solo to /usr/bin"
-ln -sf $DEST_DIR/bin/chef-apply /usr/bin || error_exit "Cannot link chef-apply to /usr/bin"
-ln -sf $DEST_DIR/bin/chef-shell /usr/bin || error_exit "Cannot link chef-shell to /usr/bin"
-ln -sf $DEST_DIR/bin/knife /usr/bin || error_exit "Cannot link knife to /usr/bin"
-ln -sf $DEST_DIR/bin/shef /usr/bin || error_exit "Cannot link shef to /usr/bin"
-ln -sf $DEST_DIR/bin/ohai /usr/bin || error_exit "Cannot link ohai to /usr/bin"
+for i in chef-client chef-solo chef-apply chef-shell knife shef ohai ; do
+  if [ "x${DEST_DIR}/bin/${i}" == x`readlink /usr/bin/${i}` -o ! -e /usr/bin/${i} ]; then
+    ln -sf ${DEST_DIR}/bin/${i} /usr/bin || error_exit "Cannot link ${i} to /usr/bin"
+  fi
+done
 
 echo "Thank you for installing Chef!"
 

--- a/package-scripts/chef/postinst
+++ b/package-scripts/chef/postinst
@@ -53,20 +53,13 @@ if [ "" != "$validation_key" ]; then
   chmod 600 ${CONFIG_DIR}/validation.pem
 fi
 
-# rm -f before ln -sf is required for solaris 9
-rm -f /usr/bin/chef-client
-rm -f /usr/bin/chef-solo
-rm -f /usr/bin/knife
-rm -f /usr/bin/shef
-rm -f /usr/bin/ohai
-
-ln -sf $INSTALLER_DIR/bin/chef-client /usr/bin || error_exit "Cannot link chef-client to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/chef-solo /usr/bin || error_exit "Cannot link chef-solo to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/chef-apply /usr/bin || error_exit "Cannot link chef-apply to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/chef-shell /usr/bin || error_exit "Cannot link chef-shell to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/knife /usr/bin || error_exit "Cannot link knife to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/shef /usr/bin || error_exit "Cannot link shef to /usr/bin"
-ln -sf $INSTALLER_DIR/bin/ohai /usr/bin || error_exit "Cannot link ohai to /usr/bin"
+for i in chef-client chef-solo chef-apply chef-shell knife shef ohai ; do
+  if [ "x${INSTALLER_DIR}/bin/${i}" == x`readlink /usr/bin/${i}` -o ! -e /usr/bin/${i} ]; then
+    # rm -f before ln -sf is required for solaris 9
+    rm -f /usr/bin/${i}
+    ln -sf ${INSTALLER_DIR}/bin/${i} /usr/bin || error_exit "Cannot link ${i} to /usr/bin"
+  fi
+done
 
 echo "Thank you for installing Chef!"
 

--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+INSTALLER_DIR=/opt/chef
+
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022
 if [ ! -e /etc/redhat-release -o "x$1" == "x0" ]; then
-  rm -f /usr/bin/chef-client
-  rm -f /usr/bin/chef-solo
-  rm -f /usr/bin/shef
-  rm -f /usr/bin/knife
-  rm -f /usr/bin/ohai
+  for i in chef-client chef-solo chef-apply chef-shell knife shef ohai ; do
+    if [ "x${INSTALLER_DIR}/bin/${i}" == x`readlink /usr/bin/${i}` ]; then
+      rm -f /usr/bin/${i}
+    fi
+  done
 fi
-


### PR DESCRIPTION
omnibus chef client installer should not overwrite /usr/bin symlinks.
if current symlinks point /opt/chef contents, then overwrite them.
