### PR TITLE
CHEF-4196 remove chef-apply & chef-shell links

### DIFF
--- a/package-scripts/chef/postinst
+++ b/package-scripts/chef/postinst
@@ -67,6 +67,8 @@ fi
 # rm -f before ln -sf is required for solaris 9
 rm -f $PREFIX/bin/chef-client
 rm -f $PREFIX/bin/chef-solo
+rm -f $PREFIX/bin/chef-apply
+rm -f $PREFIX/bin/chef-shell
 rm -f $PREFIX/bin/knife
 rm -f $PREFIX/bin/shef
 rm -f $PREFIX/bin/ohai

--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -16,6 +16,8 @@ fi
 if [ ! -e /etc/redhat-release -o "x$1" == "x0" ]; then
   rm -f $PREFIX/bin/chef-client
   rm -f $PREFIX/bin/chef-solo
+  rm -f $PREFIX/bin/chef-apply
+  rm -f $PREFIX/bin/chef-shell
   rm -f $PREFIX/bin/shef
   rm -f $PREFIX/bin/knife
   rm -f $PREFIX/bin/ohai


### PR DESCRIPTION
These links need to be deleted when the package is removed.

According to the documentation they also need to be deleted before recreating the links on a Solaris 9 system.
