### PR TITLE
Bump windows ruby version to p429

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -16,12 +16,12 @@
 #
 
 name "ruby-windows"
-version "1.9.3-p286"
+version "1.9.3-p429"
 
 relative_path "ruby-#{version}-i386-mingw32"
 
-source :url => "http://rubyforge.org/frs/download.php/76528/ruby-#{version}-i386-mingw32.7z",
-       :md5 => "8ba0d2203590dbf8e9d59d9d731c05d0"
+source :url => "http://rubyforge.org/frs/download.php/76953/ruby-#{version}-i386-mingw32.7z",
+       :md5 => "cb415faeee5d02dd799619c090e6ffe2"
 
 build do
   # Robocopy's return code is 1 if it succesfully copies over the


### PR DESCRIPTION
1.9.3-p429 includes large performance improvements that greatly improves the experience of chef on windows.  Client utilities like knife run 3-5x faster than with p286 (`knife help` can take as much as 15s on my windows laptop, with p429 the time is reduced to ~2s)
