### PR TITLE
Fix versions of windows gem dependencies in the MSI.

### DIFF
--- a/config/software/chef-windows.rb
+++ b/config/software/chef-windows.rb
@@ -99,10 +99,6 @@ build do
 
   rake "gem"
 
-  gem ["install pkg/chef*.gem",
-       "-n #{install_dir}/bin",
-       "--no-rdoc --no-ri"].join(" ")
-
   aux_gems = {
     "ffi"           => "1.3.1",
     "win32-api"     => "1.4.8",
@@ -117,12 +113,14 @@ build do
     "windows-pr"    => "1.2.2"
   }
 
-
-
   aux_gems.each do |gem_name, version|
     gem ["install", gem_name, "-v", version, "--no-rdoc --no-ri"].join(" ")
   end
 
+
+  gem ["install pkg/chef*.gem",
+       "-n #{install_dir}/bin",
+       "--no-rdoc --no-ri"].join(" ")
 
   # render batch files
   #


### PR DESCRIPTION
Install windows gems before chef gem so the dependendies are installed based on intended versions.
