### PR TITLE
install gem before bundle installing

### DIFF
--- a/config/software/chef-windows.rb
+++ b/config/software/chef-windows.rb
@@ -97,14 +97,14 @@ build do
     command "mklink C:\\opscode\\chef\\bin\\#{target} C:\\opscode\\chef\\embedded\\mingw\\bin\\#{to}"
   end
 
-  # XXX: doing a normal bundle_bust here results in gems installed into the outer bundle...
-  command "bundle install", :env => { "PATH" => "#{install_dir}/embedded/bin;#{install_dir}/embedded/mingw/bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem", "BUNDLE_BIN_PATH" => "#{install_dir}/embedded/bin/bundle" , "BUNDLE_GEMFILE" => nil, "GEM_HOME" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "GEM_PATH" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "RUBYOPT" => nil }
-
   rake "gem"
 
   gem ["install pkg/chef*mingw32.gem",
        "-n #{install_dir}/bin",
        "--no-rdoc --no-ri"].join(" ")
+
+  # XXX: doing a normal bundle_bust here results in gems installed into the outer bundle...
+  command "bundle install", :env => { "PATH" => "#{install_dir}/embedded/bin;#{install_dir}/embedded/mingw/bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem", "BUNDLE_BIN_PATH" => "#{install_dir}/embedded/bin/bundle" , "BUNDLE_GEMFILE" => nil, "GEM_HOME" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "GEM_PATH" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "RUBYOPT" => nil }
 
   # render batch files
   #


### PR DESCRIPTION
- this was forgotten in the 11.6.2 ohai symlink fix, and windows
  is broken (but nobody will care because /opt/chef/embedded/bin is in
  the windows PATH -- which is terrible and should get fixed)
- doing things two different ways on windows and unix is most
  likely bad and confusing
