### PR TITLE
[CHEF-4973] Fix Freebsd vagrant box naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The only requirements for standing up this virtualized build lab are:
 from the [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads).
 * Vagrant 1.2.1+ - native packages exist for most platforms and can be downloaded
 from the [Vagrant downloads page](http://downloads.vagrantup.com/).
+* NOTE: If you are building omnibus-chef for any FreeBSD release - you must be
+using Vagrant > 1.5.0 which includes multiple FreeBSD fixes.
 
 The [vagrant-berkshelf](https://github.com/RiotGames/vagrant-berkshelf) and
 [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus) Vagrant plugins

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,25 +6,6 @@ require "vagrant"
 if Vagrant::VERSION < "1.2.1"
   raise "The Omnibus Build Lab is only compatible with Vagrant 1.2.1+"
 end
-#
-# This is fixed as part of vagrant 1.5 - monkeypatch it here
-# This allows freebsd NFS shared folders to work
-# https://github.com/mitchellh/vagrant/issues/2749#issuecomment-32691701
-if Vagrant::VERSION < "1.5.0"
-  require Vagrant.source_root.join("plugins", "provisioners", "chef", "provisioner", "chef_solo")
-  class VagrantPlugins::Chef::Provisioner::ChefSolo
-    def share_folders(root_config, prefix, folders)
-      folders.each do |type, local_path, remote_path|
-        if type == :host
-          root_config.vm.synced_folder(
-          local_path, remote_path,
-          :id =>  "v-#{prefix}-#{self.class.get_and_update_counter(:shared_folder)}",
-          :type => (@config.nfs ? :nfs : nil))
-        end
-      end
-    end
-  end
-end
 
 host_project_path = File.expand_path("..", __FILE__)
 guest_project_path = "/home/vagrant/#{File.basename(host_project_path)}"
@@ -82,7 +63,7 @@ Vagrant.configure('2') do |config|
         major_version = platform.split(/freebsd-(.*)\..*/).last
 
         c.vm.guest = :freebsd
-        c.vm.box = "dyn-#{platform}"
+        c.vm.box = platform
         c.vm.box_url = "http://dyn-vm.s3.amazonaws.com/vagrant/#{platform}_chef-11.8.0.box"
         c.vm.network :private_network, :ip => "33.33.33.#{50 + index}"
 


### PR DESCRIPTION
This commit includes
- Fixes for Vagrant bug in <1.5 with shared folders
- Updates to URL for Dyn backed Freebsd boxes
- Update default 8.3 and 9.1 boxes for chef 11.8.0
