### PR TITLE
Disable chef-solo run on slaves as a temporary quick fix to unblock Mac builds.

### DIFF
--- a/jenkins/build
+++ b/jenkins/build
@@ -93,7 +93,13 @@ if [ "x$os" != "xAIX" ]; then
     dna=`pwd`/jenkins/dna.json
   fi
   # Omnibus build server prep tasks, including build ruby
-  sudo -i env PATH=$PATH chef-solo -c `pwd`/jenkins/solo.rb -j $dna -l debug
+  # TEMPORARY: Temporarily disable chef-solo runs. 
+  # Can be reverted when https://github.com/opscode-cookbooks/omnibus/pull/12 
+  # is merged and released.
+  # Note that currently this functionality is not needed since we are far away 
+  # from rebuilding slaves using cookbooks in ci.opscode.us.
+  # sudo -i env PATH=$PATH chef-solo -c `pwd`/jenkins/solo.rb -j $dna -l debug
+  # END of temporary change.
   # Fix root-owned perms left over from running chef-solo (cache turds, etc)
   set +e
   sudo chown -R jenkins-node `pwd` || sudo chown -R jenkins `pwd` 


### PR DESCRIPTION
Can be reverted when https://github.com/opscode-cookbooks/omnibus/pull/12 is merged and released.

Note that currently this functionality is not needed since we are far away from rebuilding slaves using cookbooks in ci.opscode.us.
