### PR TITLE
Use SemVer build version for ChefDK projects

### DIFF
--- a/config/projects/chefdk-windows.rb
+++ b/config/projects/chefdk-windows.rb
@@ -23,8 +23,8 @@ homepage "http://www.opscode.com"
 #       Native gems will use gcc which will barf on files with spaces,
 #       which is only fixable if everyone in the world fixes their Makefiles
 install_path    "c:\\opscode\\chefdk"
-build_version   Omnibus::BuildVersion.full
-build_iteration 4
+build_version   Omnibus::BuildVersion.new.semver
+build_iteration 1
 
 package_name    "chef-dk"
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -20,8 +20,8 @@ maintainer "Opscode, Inc."
 homepage   "http://www.opscode.com"
 
 install_path    "/opt/chefdk"
-build_version   Omnibus::BuildVersion.full
-build_iteration 4
+build_version   Omnibus::BuildVersion.new.semver
+build_iteration 1
 
 override :berkshelf, version: "v3.0.0.beta7"
 override :bundler,   version: "1.5.2"


### PR DESCRIPTION
This format produced a fully SemVer-compliant build version like:

MAJOR.MINOR.PATCH-PRERELEASE+TIMESTAMP.git.COMMITS_SINCE.GIT_SHA

The timestamp can optionally be omitted by passing the `--no-timestamp` 
to the `omnibus` CLI.

I ran a full-matrix test of this through CI also:
http://manhattan.ci.opscode.us/view/CHEFDK%3A%20Omnibus%20Build%20Pipeline/job/chefdk-trigger-ad_hoc/3/downstreambuildview/

/cc @opscode/release-engineers @opscode/client-eng 
