### PR TITLE
support 14.04 via old endpoints

### DIFF
--- a/jenkins/chef.json
+++ b/jenkins/chef.json
@@ -182,6 +182,11 @@
             "ubuntu",
             "13.10",
             "x86_64"
+        ],
+        [
+            "ubuntu",
+            "14.04",
+            "x86_64"
         ]
     ],
     "build_os=ubuntu-11-04,machine_architecture=x86,role=oss-builder": [
@@ -217,6 +222,11 @@
         [
             "ubuntu",
             "13.10",
+            "i686"
+        ],
+        [
+            "ubuntu",
+            "14.04",
             "i686"
         ]
     ],


### PR DESCRIPTION
omnibus-updater still uses the old v1 download endpoints, so we need this in order to support 14.04 on release day correctly.
