### PR TITLE
Add rubygems customization file when building chefdk

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -40,4 +40,5 @@ override :zlib,      version: "1.2.8"
 
 dependency "preparation"
 dependency "chefdk"
+dependency "rubygems-customization"
 dependency "version-manifest"

--- a/config/software/rubygems-customization.rb
+++ b/config/software/rubygems-customization.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubygems-customization"
+
+default_version "0.1.0"
+
+if platform == 'windows'
+  dependency "ruby-windows"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+
+
+#/opt/chefdk/embedded/bin/ruby -e 'puts Gem.dir'
+# => /opt/chefdk/embedded/lib/ruby/gems/2.1.0
+#
+# /opt/chefdk/embedded/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"
+# => /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0
+
+# result should be /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/defaults/operating_system.rb
+
+
+build do
+
+  block do
+    source_customization_file = File.join(project.files_path, "rubygems_customization", "operating_system.rb")
+    embedded_ruby_site_dir = ""
+    Bundler.with_clean_env do
+      embedded_ruby_site_dir = %x{/opt/chefdk/embedded/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"}.strip
+    end
+
+    raise "could not determine embedded ruby's site dir" if embedded_ruby_site_dir.empty?
+
+    destination_dir = File.join(embedded_ruby_site_dir, 'rubygems', 'defaults')
+    destination = File.join(destination_dir, "operating_system.rb")
+
+    FileUtils.mkdir_p destination_dir
+    command "cp #{source_customization_file} #{destination}"
+  end
+end
+

--- a/files/rubygems_customization/operating_system.rb
+++ b/files/rubygems_customization/operating_system.rb
@@ -1,0 +1,22 @@
+## Rubygems Customization ##
+# Customize rubygems install behavior and locations to keep user gems isolated
+# from the stuff we bundle with omnibus and any other ruby installations on the
+# system.
+
+# Always install and update new gems in "user install mode"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["install"] = "--user"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["update"] = "--user"
+
+module Gem
+
+  ##
+  # Override user_dir to live inside of ~/.chefdk
+
+  def self.user_dir
+    parts = [Gem.user_home, '.chefdk', 'gem', ruby_engine]
+    parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
+    File.join parts
+  end
+
+end
+


### PR DESCRIPTION
This adds an "operating_system" customization file to our rubygems install when building ChefDK. It does the following:
- Sets `--user` by default when installing or updating gems via `chef gem`
- Customizes the rubygems user dir to be `~/.chefdk/gem`
