### PR TITLE
CHEF-5208: Omnibus RPM doesn't create symlinks on upgrade

### DIFF
--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -7,8 +7,7 @@
 #   this programming language.  do not touch.
 # - if you are under 40, get peer review from your elders.
 
-is_smartos()
-{
+is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
@@ -18,14 +17,19 @@ else
     PREFIX="/usr"
 fi
 
+cleanup_symlinks() {
+  binaries="chef-client chef-solo chef-apply chef-shell knife shef ohai"
+  for binary in $binaries; do
+    rm -f $PREFIX/bin/$binary
+  done
+}
+
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022
-if [ ! -f /etc/redhat-release -o "x$1" = "x0" ]; then
-  rm -f $PREFIX/bin/chef-client
-  rm -f $PREFIX/bin/chef-solo
-  rm -f $PREFIX/bin/chef-apply
-  rm -f $PREFIX/bin/chef-shell
-  rm -f $PREFIX/bin/shef
-  rm -f $PREFIX/bin/knife
-  rm -f $PREFIX/bin/ohai
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ -o "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
 fi

--- a/package-scripts/chefdk/postrm
+++ b/package-scripts/chefdk/postrm
@@ -7,8 +7,7 @@
 #   this programming language.  do not touch.
 # - if you are under 40, get peer review from your elders.
 
-is_smartos()
-{
+is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
@@ -18,12 +17,19 @@ else
     PREFIX="/usr"
 fi
 
-binaries="chef chef-solo chef-apply chef-shell knife shef ohai berks chef-zero fauxhai foodcritic kitchen rubocop strain strainer chef-client"
-
-# Clean up binary symlinks if they exist
-# see: http://tickets.opscode.com/browse/CHEF-3022
-if [ ! -f /etc/redhat-release -o "x$1" = "x0" ]; then
+cleanup_symlinks() {
+  binaries="chef chef-solo chef-apply chef-shell knife shef ohai berks chef-zero fauxhai foodcritic kitchen rubocop strain strainer chef-client"
   for binary in $binaries; do
     rm -f $PREFIX/bin/$binary
   done
+}
+
+# Clean up binary symlinks if they exist
+# see: http://tickets.opscode.com/browse/CHEF-3022
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ -o "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
 fi


### PR DESCRIPTION
fixes RPM uninstall/upgrade logic for Amazon Linux and Fedora which
both now lack /etc/redhat-release
