### PR TITLE
Altenative override of user_install default for gem install

### DIFF
--- a/files/rubygems_customization/operating_system.rb
+++ b/files/rubygems_customization/operating_system.rb
@@ -3,10 +3,6 @@
 # from the stuff we bundle with omnibus and any other ruby installations on the
 # system.
 
-# Always install and update new gems in "user install mode"
-Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["install"] = "--user"
-Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["update"] = "--user"
-
 module Gem
 
   ##
@@ -18,5 +14,21 @@ module Gem
     File.join parts
   end
 
+end
+
+class Gem::Installer
+
+  #
+  # override the gem installer to default to user mode installation for non-root users
+  #
+
+  old_initialize = instance_method(:initialize)
+  define_method(:initialize) do |gem, options|
+    options ||= {}
+    unless Process.euid == 0
+      options[:user_install] = true
+    end
+    old_initialize.bind(self).(gem, options)
+  end
 end
 


### PR DESCRIPTION
- this works even if .gemrc contains an install: line
- if you sudo gem install <whatever> it will go into the omnibus
  location, which seems more like DWIM to me
