### PR TITLE
update vagrant build config

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
-site :opscode
+source "http://api.berkshelf.com"
 
 cookbook "omnibus"
+cookbook "apt"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,52 +1,23 @@
-{
-  "sources": {
-    "omnibus": {
-      "locked_version": "1.2.2"
-    },
-    "apt": {
-      "locked_version": "1.9.2"
-    },
-    "build-essential": {
-      "locked_version": "1.4.2"
-    },
-    "git": {
-      "locked_version": "2.3.0"
-    },
-    "dmg": {
-      "locked_version": "2.0.8"
-    },
-    "yum": {
-      "locked_version": "2.4.4"
-    },
-    "windows": {
-      "locked_version": "1.11.0"
-    },
-    "chef_handler": {
-      "locked_version": "1.1.4"
-    },
-    "runit": {
-      "locked_version": "1.4.0"
-    },
-    "homebrew": {
-      "locked_version": "1.3.2"
-    },
-    "pkgin": {
-      "locked_version": "0.4.0"
-    },
-    "pkgutil": {
-      "locked_version": "0.0.3"
-    },
-    "rbenv": {
-      "locked_version": "1.6.5"
-    },
-    "ohai": {
-      "locked_version": "1.1.12"
-    },
-    "wix": {
-      "locked_version": "1.1.0"
-    },
-    "7-zip": {
-      "locked_version": "1.0.2"
-    }
-  }
-}
+DEPENDENCIES
+  apt
+  omnibus
+
+GRAPH
+  7-zip (1.0.2)
+    windows (>= 1.2.2)
+  apt (2.3.10)
+  build-essential (2.0.0)
+  chef-sugar (1.2.8)
+  chef_handler (1.1.6)
+  homebrew (1.6.0)
+  omnibus (2.0.2)
+    7-zip (~> 1.0)
+    build-essential (~> 2.0)
+    chef-sugar (~> 1.1)
+    homebrew (~> 1.5)
+    windows (~> 1.30)
+    wix (~> 1.1)
+  windows (1.30.2)
+    chef_handler (>= 0.0.0)
+  wix (1.1.0)
+    windows (>= 1.2.2)


### PR DESCRIPTION
- omnibus 2.0.2 fixes
- berkshelf 3 fixes
- vagrant 1.5.x fixes

this also fixes bugginess in the omnibus nuker shell scriptlet, the other scriptlet needed changes for the chruby introduced in omnibus 2.0.2, and we have to explicitly add the apt cookbook now because of `$reasons`.
