### PR TITLE
Remove the leftover -a in the postrm scripts on centos.

### DIFF
--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -29,7 +29,7 @@ cleanup_symlinks() {
 if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release ]; then
   # not a redhat-ish RPM-based system
   cleanup_symlinks
-elif [ -o "x$1" = "x0" ]; then
+elif [ "x$1" = "x0" ]; then
   # RPM-based system and we're deinstalling rather than upgrading
   cleanup_symlinks
 fi

--- a/package-scripts/chefdk/postrm
+++ b/package-scripts/chefdk/postrm
@@ -29,7 +29,7 @@ cleanup_symlinks() {
 if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release ]; then
   # not a redhat-ish RPM-based system
   cleanup_symlinks
-elif [ -o "x$1" = "x0" ]; then
+elif [ "x$1" = "x0" ]; then
   # RPM-based system and we're deinstalling rather than upgrading
   cleanup_symlinks
 fi


### PR DESCRIPTION
@lamont-granquist tested this on Centos 5.9 and now /usr/bin is clear of chef binaries.
