### PR TITLE
Add libffi to support building chefdk on debian

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -46,6 +46,7 @@ override :rubygems,  version: "2.2.1"
 override :yajl,      version: "1.2.0"
 override :zlib,      version: "1.2.8"
 
+dependency "libffi" if debian?
 dependency "preparation"
 dependency "chefdk"
 dependency "rubygems-customization"


### PR DESCRIPTION
On debian the health check fails on libffi, so add it as a dependency when building on debian.
