### PR TITLE
Add build scripts for “new” CI

### DIFF
--- a/jenkins/verify-chefdk.bat
+++ b/jenkins/verify-chefdk.bat
@@ -1,0 +1,32 @@
+
+@ECHO OFF
+
+cd C:\opscode\chefdk\bin
+
+ECHO(
+
+FOR %%b IN (
+  berks
+  chef
+  chef-client
+  kitchen
+  knife
+  rubocop
+) DO (
+
+
+  ECHO Checking for existence of binfile `%%b`...
+
+  IF EXIST %%b (
+
+    ECHO ...FOUND IT!
+
+  ) ELSE (
+
+    GOTO :error
+
+  )
+  ECHO(
+)
+
+chef verify

--- a/jenkins/verify-chefdk.sh
+++ b/jenkins/verify-chefdk.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export PATH=/opt/chefdk/bin:$PATH
+sudo chef verify --unit --integration


### PR DESCRIPTION
These scripts will allow projects to be built in the opscode-ci managed
clusters (e.g. manhattan). This PR will be leveraged by https://github.com/opscode-cookbooks/opscode-ci/pull/122

/cc @opscode/client-eng @opscode/release-engineers 
