### PR TITLE
Switch chefdk artifacts to use semver to make sure the artifact names of nightly builds are not duplicated.

### DIFF
--- a/config/projects/chefdk-windows.rb
+++ b/config/projects/chefdk-windows.rb
@@ -31,7 +31,7 @@ build_version do
   source :git, from_dependency: 'chefdk'
 
   # Set a Rubygems style version
-  output_format :git_describe
+  output_format :semver
 end
 
 package_name    "chef-dk"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -28,7 +28,7 @@ build_version do
   source :git, from_dependency: 'chefdk'
 
   # Set a Rubygems style version
-  output_format :git_describe
+  output_format :semver
 end
 
 mac_pkg_identifier "com.getchef.pkg.chefdk"


### PR DESCRIPTION
cc: @schisamo 

I'll be running a build with this soon to verify the change.
