### PR TITLE
Include ohai

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus-software', :github => 'opscode/omnibus-software',
-  :branch => 'include-ohai'
+  :branch => 'master'
 
 gem 'omnibus', :github => 'opscode/omnibus-ruby',
   :branch => 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 6658506417e25cbd088b6ea736f652d218840a6f
-  branch: include-ohai
+  revision: da6df9a70a95ae3cfc8ca63606f807db8317782f
+  branch: master
   specs:
     omnibus-software (0.0.1)
 


### PR DESCRIPTION
Add ohai as a dependency to Chef-DK, so that it works "out of the box". Built locally on Mac and Windows, current running CI tests.

See also" https://github.com/opscode/omnibus-software/pull/230

@opscode/client-eng 
