### PR TITLE
Output a SemVer compliant build version string in all Client projects

### DIFF
--- a/config/projects/angrychef.rb
+++ b/config/projects/angrychef.rb
@@ -28,8 +28,8 @@ build_version do
   # Use chef to determine the build version
   source :git, from_dependency: 'chef'
 
-  # Set a Rubygems style version
-  output_format :git_describe
+  # Output a SemVer compliant version string
+  output_format :semver
 end
 
 install_dir "/opt/angrychef"

--- a/config/projects/chef-windows.rb
+++ b/config/projects/chef-windows.rb
@@ -30,8 +30,8 @@ build_version do
   # Use chef to determine the build version
   source :git, from_dependency: 'chef-windows'
 
-  # Set a Rubygems style version
-  output_format :git_describe
+  # Output a SemVer compliant version string
+  output_format :semver
 end
 
 package_name    "chef-client"

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -25,8 +25,8 @@ build_version do
   # Use chef to determine the build version
   source :git, from_dependency: 'chef'
 
-  # Set a Rubygems style version
-  output_format :git_describe
+  # Output a SemVer compliant version string
+  output_format :semver
 end
 
 install_dir    "/opt/chef"

--- a/config/projects/chefdk-windows.rb
+++ b/config/projects/chefdk-windows.rb
@@ -30,7 +30,7 @@ build_version do
   # Use chefdk to determine the build version
   source :git, from_dependency: 'chefdk'
 
-  # Set a Rubygems style version
+  # Output a SemVer compliant version string
   output_format :semver
 end
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -27,7 +27,7 @@ build_version do
   # Use chefdk to determine the build version
   source :git, from_dependency: 'chefdk'
 
-  # Set a Rubygems style version
+  # Output a SemVer compliant version string
   output_format :semver
 end
 


### PR DESCRIPTION
We currently use the `:git_describe` version for all Client projects. This build version format does not respect `Omnibus::Config.append_timestamp` which in turn causes two different builds to produce packages named identically. This can wreck havoc on when packages are published to backends like Omnitruck and Artifactory.

I've had conversations with @sersut about why we are clinging to the `:git_describe` version in client projects and it's related to Chef bootstrapping (`knife bootstrap`). The bootstrapping process pulls the Chef version from the internal Chef gem. This version string is in turn sent in the request to Omnitruck. Rubygem's handles pre-release version numbers slightly different than SemVer does. In particular it separates the `MAJOR.MINOR.PATCH` from the pre-release indicator with a dot (`.`) instead of a dash (`-`) (e.g. `11.14.0.rc.2` vs `11.14.0-rc.2`).

I've done some testing and Omnitruck does in fact "do the right thing". It treats Rubygem and Semver pre-release versions identically and properly retrieves metadata and packages. This works because Omnitruck now [parses any version string into an `Opscode::Version` instance](https://github.com/opscode/opscode-omnitruck/blob/rel-1.1.11/app.rb#L224-L270) before doing comparisons or queries.

Here are examples of requesting metadata for Chef 11.14.0.rc.2 in Rubygem and SemVer formatted version strings:

```
$  curl "http://www.getchef.com/chef/metadata?p=ubuntu&pv=12.04&m=x86_64&v=11.14.0.rc.2&prerelease=true"
url http://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.14.0.rc.2-1_amd64.deb
md5 716f8bffec19e7dddfc9ea0b8813953f
sha256  7b9c80ac3e2fcf00a7335da2ad003c991cf6e67d0b9b94f11b160bb0682d231c
$  curl "http://www.getchef.com/chef/metadata?p=ubuntu&pv=12.04&m=x86_64&v=11.14.0-rc.2&prerelease=true"
url http://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.14.0.rc.2-1_amd64.deb
md5 716f8bffec19e7dddfc9ea0b8813953f
sha256  7b9c80ac3e2fcf00a7335da2ad003c991cf6e67d0b9b94f11b160bb0682d231c
```

So in conclusion (sorry for the essay) we can safely move all Client projects to SemVer build versions!

/cc @opscode/release-engineers @opscode/client-engineers @christophermaier 
