### PR TITLE
rubygems-customization before ruby-windows-devkit

### DIFF
--- a/config/projects/chefdk-windows.rb
+++ b/config/projects/chefdk-windows.rb
@@ -51,10 +51,11 @@ override :zlib,      version: "1.2.8"
 
 dependency "preparation"
 dependency "ruby-windows"
+dependency "rubygems-customization"
+# The devkit has to be installed after rubygems-customization so the file it installs gets patched
 dependency "ruby-windows-devkit"
 dependency "chef-windows"
 dependency "chefdk"
-dependency "rubygems-customization"
 dependency "version-manifest"
 
 resources_path File.join(files_path, "chefdk")


### PR DESCRIPTION
Fixes opscode/chef-dk#100

rubygems-customization drops in a custom operating_system.rb, after the devkit install
has modified the regular version of this file. However, if we install the devkit after
we place this file, the devkit will modify the custom version.
