### PR TITLE
Updated `omnibus` with `*.metadata.json` fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 40f75279c5198d5be6a11642dd6bb1e534bfbba5
+  revision: c9287386a49a80cae13b74e949313b4b6717c159
   branch: master
   specs:
     omnibus-software (0.0.1)


### PR DESCRIPTION
The latest version of Omnibus contains important fixes for the generated metadata files. In particular the following items are fixed:
- `*.metadata.json` files are properly copied over to $PWD/pkg at build completion on Windows builders: opscode/omnibus-ruby@f90842b
- Latest version of Ohai properly retrieves platform and platform version on Windows builders: opscode/omnibus-ruby@bfedf87
- Build iteration has been added to `*.metadata.json` for use in publishing tasks: opscode/omnibus-ruby@3dfd9b3

This PR also partially addresses issues raised in opscode/oc_post_mortems#33.

/cc @opscode/release-engineers @opscode/client-engineers 
