### PR TITLE
Update omnibus to pull in updated `ffi-yajl` and `libyajl2`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-ruby.git
-  revision: ab7a856bc8dfc0022990c4d878840b2d5702647c
+  revision: 1fd1840f48c98d29e86314b40c66d720c3de7c8e
   branch: master
   specs:
     omnibus (3.2.0.rc.1)
@@ -31,7 +31,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     clamp (0.6.3)
     ffi (1.9.3)
-    ffi-yajl (0.2.0)
+    ffi-yajl (0.2.1)
       ffi (~> 1.5)
       libyajl2
     fpm (0.4.42)
@@ -50,7 +50,7 @@ GEM
     http_parser.rb (0.5.3)
     ipaddress (0.8.0)
     json (1.8.1)
-    libyajl2 (0.1.17)
+    libyajl2 (0.1.18)
     mime-types (1.25.1)
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)


### PR DESCRIPTION
Before this update `bundle install` fails as follows:

```
vagrant@chef-ubuntu-1204:~/omnibus-chef$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching additional metadata from https://rubygems.org/..
Fetching git://github.com/opscode/omnibus-ruby.git
Fetching git://github.com/opscode/omnibus-software.git
Installing addressable 2.3.6
Installing cabin 0.6.1
Installing arr-pm 0.0.9
Installing backports 3.6.0
Installing chef-sugar 1.3.0
Installing ffi 1.9.3
Installing childprocess 0.5.3
Installing clamp 0.6.3

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /opt/rubies/ruby-2.1.1/bin/ruby extconf.rb
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
    --with-opt-dir
    --without-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/opt/rubies/ruby-2.1.1/bin/ruby
/opt/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- libyajl2 (LoadError)
    from /opt/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from extconf.rb:3:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /home/vagrant/.gem/ruby/2.1.1/gems/ffi-yajl-0.2.0 for inspection.
Results logged to /home/vagrant/.gem/ruby/2.1.1/extensions/x86_64-linux/2.1.0-static/ffi-yajl-0.2.0/gem_make.out
An error occurred while installing ffi-yajl (0.2.0), and Bundler cannot continue.
Make sure that `gem install ffi-yajl -v '0.2.0'` succeeds before bundling.
```

I'm not sure what has been fixed in the updated versions of `ffi-yajl` and `libyajl2` as @lamont-granquist has not pushed his released code to GitHub. As these gems are dependancies for our software we need to use a grown-up release process for them just like we would for Chef, Ohai and Omnibus. We should also move both gems to the `opscode` GitHub organization.

/cc @opscode/release-engineers @opscode/client-engineers @jmink 
