### PR TITLE
Use copy instead of shelling out to cp on Windows

### DIFF
--- a/config/software/chef-windows.rb
+++ b/config/software/chef-windows.rb
@@ -72,7 +72,7 @@ build do
   }.each do |target, to|
     source = File.expand_path(File.join(install_dir, "embedded", "mingw", "bin", to)).gsub(/\//, "\\")
     target = File.expand_path(File.join(install_dir, "bin", target)).gsub(/\//, "\\")
-    command "cp #{source}  #{target}"
+    copy(source, target)
   end
 
   rake "gem"


### PR DESCRIPTION
The built in copy method doesn't require MinGW to be installed
on the build system.

This was necessary for me to build to test https://github.com/opscode/omnibus-software/pull/264, and thus has been tested already.
