### PR TITLE
Uses project.friendly_name and project.maintainer in the templates for msi

### DIFF
--- a/files/chef/windows_msi/Resources/localization-en-us.wxl.erb
+++ b/files/chef/windows_msi/Resources/localization-en-us.wxl.erb
@@ -2,8 +2,8 @@
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <!-- http://wix.codeplex.com/SourceControl/changeset/view/792e101c5cf7#src%2fext%2fUIExtension%2fwixlib%2fWixUI_en-us.wxl -->
   <String Id="LANG">1033</String>
-  <String Id="ProductName"><%= friendly_name %></String>
-  <String Id="ManufacturerName"><%= maintainer %></String>
+  <String Id="ProductName"><%= project.friendly_name %></String>
+  <String Id="ManufacturerName"><%= project.maintainer %></String>
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>

--- a/files/chefdk/windows_msi/Resources/localization-en-us.wxl.erb
+++ b/files/chefdk/windows_msi/Resources/localization-en-us.wxl.erb
@@ -2,8 +2,8 @@
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <!-- http://wix.codeplex.com/SourceControl/changeset/view/792e101c5cf7#src%2fext%2fUIExtension%2fwixlib%2fWixUI_en-us.wxl -->
   <String Id="LANG">1033</String>
-  <String Id="ProductName"><%= friendly_name %></String>
-  <String Id="ManufacturerName"><%= maintainer %></String>
+  <String Id="ProductName"><%= project.friendly_name %></String>
+  <String Id="ManufacturerName"><%= project.maintainer %></String>
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>


### PR DESCRIPTION
This fixes build issues for omnibus 3.2.0 that were broken by f717c6a5299fb2aeba4ea369379fce7ad1359334
