### PR TITLE
pin Angrychef version for 11.14.2 release

### DIFF
--- a/config/projects/angrychef.rb
+++ b/config/projects/angrychef.rb
@@ -37,6 +37,9 @@ install_path "/opt/angrychef"
 resources_path File.join(files_path, "chef")
 mac_pkg_identifier "com.getchef.pkg.angrychef"
 
+# Override chef version for release
+override :chef, version: "11.14.2"
+
 dependency "preparation"
 dependency "chef"
 dependency "version-manifest"


### PR DESCRIPTION
In the future we need to pin/bump Angrychef's Chef override version at the same time we do it in the `chef` and `chef-windows` projects.

/cc @opscode/client-engineers 
