### PR TITLE
Modified chef installer to migrate the service on update

### DIFF
--- a/resources/chef/msi/source.wxs.erb
+++ b/resources/chef/msi/source.wxs.erb
@@ -23,7 +23,7 @@
     <!-- Major upgrade -->
     <Upgrade Id="$(var.UpgradeCode)">
       <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VersionNumber)" IncludeMinimum="no" Property="NEWERVERSIONDETECTED" />
-      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.VersionNumber)" IncludeMaximum="no" Property="OLDERVERSIONBEINGUPGRADED" />
+      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.VersionNumber)" IncludeMaximum="no" Property="OLDERVERSIONBEINGUPGRADED" MigrateFeatures="yes" />
     </Upgrade>
 
     <InstallExecuteSequence>


### PR DESCRIPTION
@adamedx @btm This allows the msi installer for chef to correctly migrate features when updating, so if the feature was installed, the update step will make sure to bring it along.
