### PR TITLE
remove chef version override in chef-container

### DIFF
--- a/config/projects/chef-container.rb
+++ b/config/projects/chef-container.rb
@@ -37,9 +37,6 @@ mac_pkg_identifier "com.getchef.pkg.chef-container"
 # use the same rubygems as the chef project
 override :rubygems, version: "1.8.29"
 
-# hardcode the version of chef
-override :chef, version: "11.12.8"
-
 dependency "preparation"
 dependency "chef"
 dependency "chef-init"


### PR DESCRIPTION
going to follow client team practice of specifying version in release branch / tag
