### PR TITLE
Set SSL_CERT_FILE environment variable during MSI installation.

### DIFF
--- a/files/chef/windows_msi/Resources/source.wxs
+++ b/files/chef/windows_msi/Resources/source.wxs
@@ -46,6 +46,10 @@
                   <Environment Id="Environment"
                                Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin;[PROJECTLOCATION]embedded\bin" />
                 </Component>
+                <Component Id="SslCertPath" Guid="{5DC8CC9F-DFA7-42CA-BE17-EEA92E1A6F08}" >
+                  <Environment Id="SslEnvironment"
+                               Name="SSL_CERT_FILE" Action="create" System="yes" Value="[PROJECTLOCATION]embedded\ssl\certs\cacert.pem" />
+                </Component>
                 <Component Id="ChefClientService" Guid="{69B2D8BE-4A47-4BE3-AEE8-83FAEB6E2FAF}" >
                   <File Id="RubyExecutable" Source="$(var.ProjectSourceDir)\embedded\bin\ruby.exe" KeyPath="yes" />
                   <ServiceInstall Name="chef-client" Type="ownProcess"
@@ -67,6 +71,7 @@
     <Feature Id="ChefClientFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ChefClientPath" />
+      <ComponentRef Id="SslCertPath" />
       <ComponentRef Id="CONFIGLOCATIONDIR" />
     </Feature>
 

--- a/files/chefdk/windows_msi/Resources/source.wxs
+++ b/files/chefdk/windows_msi/Resources/source.wxs
@@ -41,6 +41,10 @@
                   <Environment Id="Environment"
                                Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin;[PROJECTLOCATION]embedded\bin" />
                 </Component>
+                <Component Id="SslCertPath" Guid="{CE028376-9253-4AD4-A4FE-D5020D22ECFD}" >
+                  <Environment Id="SslEnvironment"
+                               Name="SSL_CERT_FILE" Action="create" System="yes" Value="[PROJECTLOCATION]embedded\ssl\certs\cacert.pem" />
+                </Component>
               </Directory>
             </Directory>
           </Directory>
@@ -52,6 +56,7 @@
     <Feature Id="ChefDkFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ChefDkPath" />
+      <ComponentRef Id="SslCertPath" />
     </Feature>
 
     <!--


### PR DESCRIPTION
Fixes https://github.com/opscode/chef/issues/1534.

@adamedx / @btm / @jdmundrawala I've tried this on Windows and it works nicely. 

LMK if this looks good and I'll do the same change to chefdk as well. 

/cc: @opscode/client-engineers 
