### PR TITLE
Hardcode ruby devkit into Windows customization

### DIFF
--- a/config/projects/chefdk-windows.rb
+++ b/config/projects/chefdk-windows.rb
@@ -51,11 +51,10 @@ override :zlib,      version: "1.2.8"
 
 dependency "preparation"
 dependency "ruby-windows"
-dependency "rubygems-customization"
-# The devkit has to be installed after rubygems-customization so the file it installs gets patched
 dependency "ruby-windows-devkit"
 dependency "chef-windows"
 dependency "chefdk"
+dependency "rubygems-customization"
 dependency "version-manifest"
 
 resources_path File.join(files_path, "chefdk")

--- a/files/rubygems_customization/operating_system.rb
+++ b/files/rubygems_customization/operating_system.rb
@@ -20,3 +20,17 @@ module Gem
 
 end
 
+# :DK-BEG: override 'gem install' to enable RubyInstaller DevKit usage
+Gem.pre_install do |gem_installer|
+  unless gem_installer.spec.extensions.empty?
+    unless ENV['PATH'].include?('C:\\opscode\\chefdk\\embedded\\mingw\\bin') then
+      Gem.ui.say 'Temporarily enhancing PATH to include DevKit...' if Gem.configuration.verbose
+      ENV['PATH'] = 'C:\\opscode\\chefdk\\embedded\\bin;C:\\opscode\\chefdk\\embedded\\mingw\\bin;' + ENV['PATH']
+    end
+    ENV['RI_DEVKIT'] = 'C:\\opscode\\chefdk\\embedded'
+    ENV['CC'] = 'gcc'
+    ENV['CXX'] = 'g++'
+    ENV['CPP'] = 'cpp'
+  end
+end
+# :DK-END:


### PR DESCRIPTION
Fixes chef-dk#100 by adding hardcoding the necessary bits for the devkit
into the operating_system.rb file that we currently create to ensure gems
are installed into the users directory on Windows. Also reverts 5b99247,
as it proved only half of a solution, the other half being complicated
balancing of build-order to make sure rubygems-customization happened at
exactly the right time (before devkit, but not before bundler, at least).
