### PR TITLE
Ensure results of `Dir.glob` are sorted

### DIFF
--- a/jenkins/release.rb
+++ b/jenkins/release.rb
@@ -80,6 +80,7 @@ class ArtifactCollection
 
   def package_paths
     @package_paths ||= Dir['**/pkg/*'].
+      sort.
       reject {|path| path.include?("BUILD_VERSION") }.
       reject {|path| path.include?("metadata.json") }
   end


### PR DESCRIPTION
**TL;DR** - This will ensure the `*.dmg` files are _always_ preferred for final publishing on Mac OS X. 

**Longer explanation** - I noticed that on Mac OS X the Chef 11.16.0-rc.2 release published the `*.pkg` files instead of `*.dmg` files. After doing some digging this has happened numerous times in the past also. The culprit appears to be the default sorting applied to the results from a `Dir.glob`. This default sorting is [determined by the underlying operating system](https://bugs.ruby-lang.org/issues/8709). On Linux no sorting is applied so sometimes the `*.dmg` file comes first and others the `*.pkg` file comes first. Since [we use an `Array#find`](https://github.com/opscode/omnibus-chef/blob/c39c478753b9cc30aee10b1b045dffa7554c70e0/jenkins/release.rb#L91) to ultimately determine which package is published for a particular platform, only the first package in the list is taken into account.

Here is an example of the data in question:

``` ruby
["build_os=centos-5,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.el5.x86_64.rpm",
 "build_os=centos-5,machine_architecture=x86,role=oss-builder/pkg/chef-11.14.6-1.el5.i686.rpm",
 "build_os=centos-6,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.el6.x86_64.rpm",
 "build_os=centos-6,machine_architecture=x86,role=oss-builder/pkg/chef-11.14.6-1.el6.i686.rpm",
 "build_os=debian-6,machine_architecture=x64,role=oss-builder/pkg/chef_11.14.6-1_amd64.deb",
 "build_os=debian-6,machine_architecture=x86,role=oss-builder/pkg/chef_11.14.6-1_i386.deb",
 "build_os=freebsd-9-1,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6_1.freebsd.9.amd64.sh",
 "build_os=freebsd-9-1,machine_architecture=x86,role=oss-builder/pkg/chef-11.14.6_1.freebsd.9.i386.sh",
 "build_os=mac_os_x_10_6,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.dmg",
 "build_os=mac_os_x_10_6,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.pkg",
 "build_os=mac_os_x_10_7,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.dmg",
 "build_os=mac_os_x_10_7,machine_architecture=x64,role=oss-builder/pkg/chef-11.14.6-1.pkg",
 "build_os=solaris-10,machine_architecture=intel,role=oss-builder/pkg/chef-11.14.6-1.solaris2.5.10.solaris",
 "build_os=solaris-9,machine_architecture=sparc,role=oss-builder/pkg/chef-11.14.6-1.solaris2.5.9.solaris",
 "build_os=ubuntu-10-04,machine_architecture=x64,role=oss-builder/pkg/chef_11.14.6-1_amd64.deb",
 "build_os=ubuntu-10-04,machine_architecture=x86,role=oss-builder/pkg/chef_11.14.6-1_i386.deb",
 "build_os=ubuntu-11-04,machine_architecture=x64,role=oss-builder/pkg/chef_11.14.6-1_amd64.deb",
 "build_os=ubuntu-11-04,machine_architecture=x86,role=oss-builder/pkg/chef_11.14.6-1_i386.deb",
 "build_os=ubuntu-12-04,machine_architecture=x64,role=oss-builder/pkg/chef_11.14.6-1_amd64.deb",
 "build_os=ubuntu-12-04,machine_architecture=x86,role=oss-builder/pkg/chef_11.14.6-1_i386.deb",
 "build_os=ubuntu-13-04,machine_architecture=x64,role=oss-builder/pkg/chef_11.14.6-1_amd64.deb",
 "build_os=ubuntu-13-04,machine_architecture=x86,role=oss-builder/pkg/chef_11.14.6-1_i386.deb",
 "build_os=windows-2008r2,machine_architecture=x64,role=oss-builder/pkg/chef-windows-11.14.6-1.windows.msi"]
```

This change will need to be ported to all `release/*` branches also.

/cc @opscode/release-engineers @opscode/client-engineers 
