### PR TITLE
remove embedded path on windows

### DIFF
--- a/resources/chef/msi/source.wxs.erb
+++ b/resources/chef/msi/source.wxs.erb
@@ -44,7 +44,7 @@
               <Directory Id="EMBEDDEDBIN" Name="bin" >
                 <Component Id="ChefClientPath" Guid="{7F663F88-55A2-4E20-82BF-8BD2E60BB83A}" >
                   <Environment Id="Environment"
-                               Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin;[PROJECTLOCATION]embedded\bin" />
+                               Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin" />
                 </Component>
                 <Component Id="ChefClientService" Guid="{69B2D8BE-4A47-4BE3-AEE8-83FAEB6E2FAF}" >
                   <File Id="RubyExecutable" Source="$(var.ProjectSourceDir)\embedded\bin\ruby.exe" KeyPath="yes" />

--- a/resources/chefdk/msi/source.wxs.erb
+++ b/resources/chefdk/msi/source.wxs.erb
@@ -39,7 +39,7 @@
               <Directory Id="EMBEDDEDBIN" Name="bin" >
                 <Component Id="ChefDkPath" Guid="{AEA5727E-DAD2-48CC-ADB8-38DD0EB46C62}" >
                   <Environment Id="Environment"
-                               Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin;[PROJECTLOCATION]embedded\bin" />
+                               Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATION]bin" />
                 </Component>
               </Directory>
             </Directory>


### PR DESCRIPTION
this should have never been there, it needs to go for chef-12/chefdk
