### PR TITLE
Revert the Ruby version on windows to 2.0.0-p451

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -45,8 +45,14 @@ override :libxml2,        version: "2.9.1"
 override :libxslt,        version: "1.1.28"
 
 override :ruby,           version: "2.1.3"
-override :'ruby-windows', version: "2.1.3"
-override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+######
+# Ruby 2.1.3 is currently not working on windows due to:
+# https://github.com/ffi/ffi/issues/375
+# Enable below once above issue is fixed.
+# override :'ruby-windows', version: "2.1.3"
+# override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+override :'ruby-windows', version: "2.0.0-p451"
+######
 override :rubygems,       version: "2.4.1"
 override :'test-kitchen', version: "v1.2.1"
 override :yajl,           version: "1.2.0"


### PR DESCRIPTION
We need this in order to unblock Chef DK release due to https://github.com/ffi/ffi/issues/375.

/cc: @opscode/client-engineers 

I've manually verified this and also running http://manhattan.ci.opscode.us/job/chefdk-test/388/ (which hit an intermittent Mac test issue)
