### PR TITLE
misc fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: e1353091a9344480e9977b4735929d74de3d7328
+  revision: ff3ca773134f9152d9065a5895e006219e8d678e
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 904f07b63ac7a4f5874ebfc3736eb1e35a7242b5
+  revision: 95729f226929717cc48b01b0f435f81dab87a218
   specs:
     omnibus (4.0.0.rc.1)
       chef-sugar (~> 2.2)
@@ -47,10 +47,10 @@ GEM
       buff-ruby_engine (~> 0.1.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    celluloid-io (0.16.0)
+    celluloid-io (0.16.1)
       celluloid (>= 0.16.0)
       nio4r (>= 1.0.0)
-    chef-sugar (2.3.0)
+    chef-sugar (2.3.2)
     cleanroom (1.0.0)
     dep-selector-libgecode (1.0.2)
     dep_selector (1.0.3)
@@ -59,9 +59,8 @@ GEM
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.5)
-    ffi (1.9.5-x86-mingw32)
-    ffi-yajl (1.1.0)
+    ffi (1.9.6)
+    ffi-yajl (1.2.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.0)
     hashie (2.1.2)
@@ -70,7 +69,7 @@ GEM
     json (1.8.1)
     kitchen-vagrant (0.15.0)
       test-kitchen (~> 1.0)
-    libyajl2 (1.0.1)
+    libyajl2 (1.1.0)
     mime-types (1.25.1)
     minitar (0.5.4)
     mixlib-authentication (1.3.0)
@@ -78,8 +77,8 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.4.0)
-    mixlib-shellout (1.4.0-x86-mingw32)
+    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.0-x86-mingw32)
       win32-process (~> 0.7.1)
       windows-pr (~> 1.2.2)
     multipart-post (2.0.0)
@@ -88,7 +87,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
     nio4r (1.0.1)
-    octokit (3.3.1)
+    octokit (3.4.0)
       sawyer (~> 0.5.3)
     ohai (7.4.0)
       ffi (~> 1.9)

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -39,10 +39,15 @@ else
 end
 
 override :bundler,        version: "1.7.2"
-# TODO: bump this to 2.1.2 when we can sort out the Solaris compile issues
 override :ruby,           version: "2.1.3"
-override :'ruby-windows', version: "2.1.3"
-override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+######
+# Ruby 2.1.3 is currently not working on windows due to:
+# https://github.com/ffi/ffi/issues/375
+# Enable below once above issue is fixed.
+# override :'ruby-windows', version: "2.1.3"
+# override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+override :'ruby-windows', version: "2.0.0-p451"
+######
 override :rubygems,       version: "2.4.1"
 
 dependency "preparation"

--- a/jenkins/client-test
+++ b/jenkins/client-test
@@ -147,6 +147,11 @@ cd /opt/chef/embedded/apps/chef
 PATH=/opt/chef/bin:/opt/chef/embedded/bin:$PATH
 export PATH
 
+# ffi-yajl must run in c-extension mode or we take perf hits, so we force it
+# before running rspec so that we don't wind up testing the ffi mode
+FORCE_FFI_YAJL=ext
+export FORCE_FFI_YAJL
+
 # run against the Gemfile.lock in the appbundle'd directory
 sudo env PATH=$PATH TERM=xterm bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec
 

--- a/jenkins/client-test.bat
+++ b/jenkins/client-test.bat
@@ -19,13 +19,16 @@ call msiexec INSTALLLOCATION=C:\opscode /qb /i %TMP%\install.msi || GOTO :error
 rem # use rspec and gems from omnibus
 set PATH=C:\opscode\chef\bin;C:\opscode\chef\embedded\bin;%PATH%
 
-rem # run against the specs that are packaged in the chef gem
-rem # sorry about the chef-20 bug on the line below, but this really needs to be rewritten in powershell before then...
-cd c:\opscode\chef\embedded\lib\ruby\gems\1.9.1\gems\chef-1*
+rem # test against the appbundle'd chef bundle
+cd c:\opscode\chef\embedded\apps\chef
+
+rem # ffi-yajl must run in c-extension mode or we take perf hits, so we force it
+rem # before running rspec so that we don't wind up testing the ffi mode
+set FORCE_FFI_YAJL=ext
 
 rem # run the tests -- exclude spec/stress on windows
 rem # we do not bundle exec here in order to test against the gems in the omnibus package
-call rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional spec/unit || GOTO :error
+call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional spec/unit || GOTO :error
 
 rem # check presence of essential binaries in correct places
 


### PR DESCRIPTION
misc fixes
- bump upstream projects
- fix windows to rspec against the appbundle'd chef
- FORCE_FFI_YAJL=ext before rspec (fixes 3 hour solaris tests and will
  catch platforms where the c-ext is broken)
- roll back windows ruby to 2.0.0 :(
