### PR TITLE
Final RC tuneups.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: e73ae6e38c0f486bf47fce69128af75308baf657
+  revision: 01d362b351587d55b3b9614532736fab56abd409
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 315625851397e48758421b29205d5c74b827751c
+  revision: 132bb177ccc728f9dd11682286d04d319932948c
   specs:
     omnibus (4.0.0.rc.1)
       chef-sugar (~> 2.2)

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -51,7 +51,7 @@ end
 override :cacerts, version: '2014.08.20'
 
 override :bundler,        version: "1.7.2"
-override :ruby,           version: "2.1.3"
+override :ruby,           version: "2.1.4"
 ######
 # Ruby 2.1.3 is currently not working on windows due to:
 # https://github.com/ffi/ffi/issues/375

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -56,7 +56,7 @@ override :libtool,        version: "2.4.2"
 override :libxml2,        version: "2.9.1"
 override :libxslt,        version: "1.1.28"
 
-override :ruby,           version: "2.1.3"
+override :ruby,           version: "2.1.4"
 ######
 # Ruby 2.1.3 is currently not working on windows due to:
 # https://github.com/ffi/ffi/issues/375


### PR DESCRIPTION
- Pick up latest omnibus / omnibus-software
- Bump Ruby to 2.1.4.

Tested with [this](http://ci.opscode.us/view/Chef%20Client%20Build%20Pipeline/job/chef-client-build/1867/) CI build.
