### PR TITLE
Add batch cleanup code for windows

### DIFF
--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -26,9 +26,15 @@ default_version "0.0.2"
 build do
   if windows?
     block "Update batch files to point at embedded ruby" do
-      require 'rubygems/format'
+      load_gemspec = if Gem::VERSION >= '2'
+                       require 'rubygems/package'
+                       Gem::Package.method(:new)
+                     else
+                       require 'rubygems/format'
+                       Gem::Format.method(:from_file_by_path)
+                     end
       Dir["#{install_dir.gsub(/\\/, '/')}/embedded/lib/ruby/gems/**/cache/*.gem"].each do |gem_file|
-        Gem::Format.from_file_by_path(gem_file).spec.executables.each do |bin|
+        load_gemspec.call(gem_file).spec.executables.each do |bin|
           if File.exists?("#{install_dir}/bin/#{bin}")
             File.open("#{install_dir}/bin/#{bin}.bat", "w") do |f|
               f.puts <<-EOF


### PR DESCRIPTION
This will rebuild the batch files to use the relative path to the embedded ruby. Consequently, this will solve https://github.com/opscode/chef-dk/issues/221, however I have no idea why it is using bin\ruby.exe instead embedded\bin\ruby.exe

This change is tested by https://github.com/opscode/chef-dk/pull/235

cc @btm @sersut @opscode/client-engineers 
