### PR TITLE
Bump chef 11.18 berks 3.2.1

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -55,7 +55,6 @@ override :cacerts, version: '2014.08.20'
 # For now we'll roll back so master is in a working state.
 override :appbundler, version: "0.2.0"
 
-override :chefdk,         version: "0.3.5"
 override :berkshelf,      version: "v3.2.1"
 override :bundler,        version: "1.7.5"
 override :chef,           version: "11.18.0.rc.1"


### PR DESCRIPTION
Merges chefdk-0-stable back to master, but removes lock on chefdk version.

@opscode/client-engineers 
