### PR TITLE
Unlock appbundler version, bump to 0.4.0 via omnibus-sw

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 539890c0faa96e67a24f586cf1e88ba933dfd999
+  revision: ab19f5dedbbd10f29da3ec6087dd3dd9e94545b4
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -46,15 +46,6 @@ end
 # Software does).
 override :cacerts, version: '2014.08.20'
 
-# Appbundler 0.3.0 has two serious bugs, which cause the issue reported here:
-# https://github.com/opscode/chef-dk/issues/228
-#
-# * https://github.com/opscode/appbundler/issues/9
-# * https://github.com/opscode/appbundler/issues/10
-#
-# For now we'll roll back so master is in a working state.
-override :appbundler, version: "0.2.0"
-
 override :berkshelf,      version: "v3.2.1"
 override :bundler,        version: "1.7.5"
 override :chef,           version: "11.18.0.rc.1"


### PR DESCRIPTION
- omnibus-sw ab19f5dedbbd10f29da3ec6087dd3dd9e94545b4 bumps appbundler
  to 0.4.0
- Remote version override for appbundler in ChefDK project defn.

See also: https://github.com/opscode/omnibus-software/pull/344

@opscode/client-engineers @opscode/release-engineers 
