### PR TITLE
Unlock appbundler version, bump to 0.4.0 via omnibus-sw

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: ae1a9a63fba05940b70aa9ceb2f9f8a3efa6cdbf
+  revision: ab19f5dedbbd10f29da3ec6087dd3dd9e94545b4
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -46,9 +46,9 @@ end
 # Software does).
 override :cacerts, version: '2014.08.20'
 
-override :berkshelf,      version: "v3.1.5"
-override :bundler,        version: "1.7.2"
-override :chef,           version: "11.16.0"
+override :berkshelf,      version: "v3.2.1"
+override :bundler,        version: "1.7.5"
+override :chef,           version: "11.18.0.rc.1"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"


### PR DESCRIPTION
- omnibus-sw ab19f5dedbbd10f29da3ec6087dd3dd9e94545b4 bumps appbundler
  to 0.4.0
- Remote version override for appbundler in ChefDK project defn.

Conflicts:
    Gemfile.lock
    config/projects/chefdk.rb
