### PR TITLE
Bump knife-spork to 1.4.2

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -59,7 +59,7 @@ build do
     'chefspec'          => '4.2.0.beta.1',
     'fauxhai'           => '2.2.0',
     'rubocop'           => '0.18.1',
-    'knife-spork'       => '1.4.1',
+    'knife-spork'       => '1.4.2',
     'kitchen-vagrant'   => '0.15.0',
     # Strainer build is hosed on windows
     # 'strainer'        => '0.15.0',


### PR DESCRIPTION
@opscode/client-engineers @jonlives Any reason not to take knife-spork 1.4.2
1.4.1 is not tagged in git and does not have any specs (one of the reasons why chef verify is failing on knife-spork)
