### PR TITLE
Enable RPM signing in OLD CI’s build script

### DIFF
--- a/jenkins/build
+++ b/jenkins/build
@@ -33,6 +33,9 @@ exists() {
   fi
 }
 
+# The key used to sign RPM packages is passphrase-less
+export OMNIBUS_RPM_SIGNING_PASSPHRASE=notset
+
 if [ "x$os" = "xAIX" ]; then
   # need to unset LIBPATH on AIX (like LD_LIBRARY_PATH on Solaris, Jenkins sets this (wrongly) on AIX)
   unset LIBPATH


### PR DESCRIPTION
Omnibus 4.0+ determines if a `*.rpm` should be signed by if a signing passphrase has been set. We pass this passphrase into our Omnibus projects via the `OMNIBUS_RPM_SIGNING_PASSPHRASE` environment. If this environment variable is not set signing is effectively disabled as `ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']` returns nil.

/cc @opscode/release-engineers @opscode/client-engineers @jtimberman 
