### PR TITLE
Jdm/prepare chefdk 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 12909667bfb281f65093afb15157a7eb1523b3cc
+  revision: f9460a7abacba68033374cb98ffaa65bb9ef478d
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -70,6 +70,12 @@ override :'test-kitchen', version: "v1.3.1"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"
 
+override :'chef-provisioning', version: "v0.18"
+override :'chef-provisioning-fog', version: "v0.12"
+override :'chef-provisioning-vagrant', version: "v0.8.1"
+override :'chef-provisioning-azure', version: "v0.1"
+override :'chef-provisioning-aws', version: "v0.2.1"
+
 dependency "preparation"
 dependency "chefdk"
 dependency "chef-provisioning"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,7 +49,7 @@ override :cacerts, version: '2014.08.20'
 override :berkshelf,      version: "v3.2.3"
 override :bundler,        version: "1.7.12"
 override :chef,           version: "12.0.3"
-override :'chef-vault',   version: "5b06f5ba03385f362a6635a10e04b7f6ed595a28" # v2.4.0
+override :'chef-vault',   version: "v2.4.0"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -66,7 +66,14 @@ override :ruby,           version: "2.1.4"
 # override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
 override :'ruby-windows', version: "2.0.0-p451"
 ######
+
+######
+# rubygems 2.4.5 is not working on windows.
+# See https://github.com/rubygems/rubygems/issues/1120
+# Once this is fixed, we can bump the version
 override :rubygems,       version: "2.4.4"
+######
+
 override :'test-kitchen', version: "v1.3.1"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,7 +49,7 @@ override :cacerts, version: '2014.08.20'
 override :berkshelf,      version: "v3.2.3"
 override :bundler,        version: "1.7.12"
 override :chef,           version: "12.0.3"
-override :'chef-vault',   version: "2.4.0"
+override :'chef-vault',   version: "v2.4.0"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -47,8 +47,8 @@ end
 override :cacerts, version: '2014.08.20'
 
 override :berkshelf,      version: "v3.2.3"
-override :bundler,        version: "1.7.5"
-override :chef,           version: "11.18.0"
+override :bundler,        version: "1.7.12"
+override :chef,           version: "12.0.3"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"
@@ -65,7 +65,7 @@ override :ruby,           version: "2.1.4"
 # override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
 override :'ruby-windows', version: "2.0.0-p451"
 ######
-override :rubygems,       version: "2.4.4"
+override :rubygems,       version: "2.4.5"
 override :'test-kitchen', version: "v1.3.1"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -66,7 +66,7 @@ override :ruby,           version: "2.1.4"
 # override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
 override :'ruby-windows', version: "2.0.0-p451"
 ######
-override :rubygems,       version: "2.4.5"
+override :rubygems,       version: "2.4.4"
 override :'test-kitchen', version: "v1.3.1"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,7 +49,7 @@ override :cacerts, version: '2014.08.20'
 override :berkshelf,      version: "v3.2.3"
 override :bundler,        version: "1.7.12"
 override :chef,           version: "12.0.3"
-override :'chef-vault',   version: "v2.4.0"
+override :'chef-vault',   version: "5b06f5ba03385f362a6635a10e04b7f6ed595a28" # v2.4.0
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,6 +49,7 @@ override :cacerts, version: '2014.08.20'
 override :berkshelf,      version: "v3.2.3"
 override :bundler,        version: "1.7.12"
 override :chef,           version: "12.0.3"
+override :'chef-vault',   version: "2.4.0"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -56,7 +56,7 @@ build do
 
   # Perform multiple gem installs to better isolate/debug failures
   {
-    'chefspec'          => '4.2.0.beta.1',
+    'chefspec'          => '4.2.0',
     'fauxhai'           => '2.2.0',
     'rubocop'           => '0.18.1',
     'knife-spork'       => '1.4.2',

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -58,7 +58,7 @@ build do
   {
     'chefspec'          => '4.2.0',
     'fauxhai'           => '2.2.0',
-    'rubocop'           => '0.18.1',
+    'rubocop'           => '0.28.0',
     'knife-spork'       => '1.4.2',
     'kitchen-vagrant'   => '0.15.0',
     # Strainer build is hosed on windows


### PR DESCRIPTION
Bumping bundler, rubygems, and pinning chef to 12.0.3

Also, pinning the provisioning projects.

cc @fnichol @tyler-ball @jkeiser @chef/client-engineers 