### PR TITLE
Fix user_dir warning

### DIFF
--- a/files/rubygems-customization/default/operating_system.rb
+++ b/files/rubygems-customization/default/operating_system.rb
@@ -12,10 +12,15 @@ module Gem
   ##
   # Override user_dir to live inside of ~/.chefdk
 
-  def self.user_dir
-    parts = [Gem.user_home, '.chefdk', 'gem', ruby_engine]
-    parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
-    File.join parts
+  class << self
+    alias :_chefdk_original_user_dir :user_dir
+    remove_method :user_dir
+
+    def user_dir
+      parts = [Gem.user_home, '.chefdk', 'gem', ruby_engine]
+      parts << RbConfig::CONFIG['ruby_version'] unless RbConfig::CONFIG['ruby_version'].empty?
+      File.join parts
+    end
   end
 
 end


### PR DESCRIPTION
When running commands with `ruby -w` you get a warning about
`user_dir` being redifined:

```
$ ruby -w -e 'puts "hi"'
/opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/defaults/operating_system.rb:15: warning: method redefined; discarding old user_dir
/opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/defaults.rb:75: warning: previous definition of user_dir was here
hi
```

This fixes the problem by using `alias` and `remove_method`.