### PR TITLE
Update Chef’s verify scripts

### DIFF
--- a/jenkins/verify-chef-container.sh
+++ b/jenkins/verify-chef-container.sh
@@ -4,11 +4,17 @@ export PATH=/opt/chef/bin:$PATH
 
 # Ensure the calling environment (disapproval look Bundler) does not
 # infect our Ruby environment created by the `chef-int` cli.
-for ruby_env_var in RUBYOPT \
+for ruby_env_var in _ORIGINAL_GEM_PATH \
                     BUNDLE_BIN_PATH \
                     BUNDLE_GEMFILE \
+                    GEM_HOME \
                     GEM_PATH \
-                    GEM_HOME
+                    GEM_ROOT \
+                    RUBYLIB \
+                    RUBYOPT \
+                    RUBY_ENGINE \
+                    RUBY_ROOT \
+                    RUBY_VERSION
 do
   unset $ruby_env_var
 done

--- a/jenkins/verify-chef.bat
+++ b/jenkins/verify-chef.bat
@@ -5,6 +5,10 @@ REM ; %PROJECT_NAME% is set by Jenkins, this allows us to use the same script to
 REM ; Chef and Angry Chef
 cd C:\opscode\%PROJECT_NAME%\bin
 
+REM ; We don't want to add the embedded bin dir to the main PATH as this
+REM ; could mask issues in our binstub shebangs.
+SET EMBEDDED_BIN_DIR=C:\opscode\%PROJECT_NAME%\embedded\bin
+
 ECHO(
 
 FOR %%b IN (
@@ -29,4 +33,16 @@ FOR %%b IN (
   ECHO(
 )
 
-chef-client --version
+call chef-client --version
+
+REM ; Exercise various packaged tools to validate binstub shebangs
+call %EMBEDDED_BIN_DIR%\ruby --version
+call %EMBEDDED_BIN_DIR%\gem --version
+call %EMBEDDED_BIN_DIR%\bundle --version
+call %EMBEDDED_BIN_DIR%\rspec --version
+
+SET PATH=C:\opscode\%PROJECT_NAME%\bin;C:\opscode\%PROJECT_NAME%\embedded\bin;%PATH%
+
+REM ; Test against the appbundle'd Chef
+cd c:\opscode\%PROJECT_NAME%\embedded\apps\chef
+call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional spec/unit

--- a/jenkins/verify-chef.sh
+++ b/jenkins/verify-chef.sh
@@ -2,7 +2,13 @@
 
 # $PROJECT_NAME is set by Jenkins, this allows us to use the same script to verify
 # Chef and Angry Chef
-export PATH=/opt/$PROJECT_NAME/bin:$PATH
+PATH=/opt/$PROJECT_NAME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+# We don't want to add the embedded bin dir to the main PATH as this
+# could mask issues in our binstub shebangs.
+EMBEDDED_BIN_DIR=/opt/$PROJECT_NAME/embedded/bin
+export PATH
 
 # sanity check that we're getting symlinks from the pre-install script
 if [ ! -L "/usr/bin/chef-client" ]; then
@@ -37,3 +43,21 @@ do
 done
 
 chef-client --version
+
+# Exercise various packaged tools to validate binstub shebangs
+$EMBEDDED_BIN_DIR/ruby --version
+$EMBEDDED_BIN_DIR/gem --version
+$EMBEDDED_BIN_DIR/bundle --version
+$EMBEDDED_BIN_DIR/rspec --version
+
+# ffi-yajl must run in c-extension mode or we take perf hits, so we force it
+# before running rspec so that we don't wind up testing the ffi mode
+FORCE_FFI_YAJL=ext
+export FORCE_FFI_YAJL
+
+PATH=/opt/$PROJECT_NAME/bin:/opt/$PROJECT_NAME/embedded/bin:$PATH
+export PATH
+
+# Test against the appbundle'd Chef
+cd /opt/$PROJECT_NAME/embedded/apps/chef
+sudo env PATH=$PATH TERM=xterm bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit

--- a/jenkins/verify-chef.sh
+++ b/jenkins/verify-chef.sh
@@ -33,11 +33,18 @@ fi
 
 # Ensure the calling environment (disapproval look Bundler) does not
 # infect our Ruby environment created by the `chef-client` cli.
-for ruby_env_var in RUBYOPT \
+for ruby_env_var in _ORIGINAL_GEM_PATH \
                     BUNDLE_BIN_PATH \
                     BUNDLE_GEMFILE \
+                    GEM_HOME \
                     GEM_PATH \
-                    GEM_HOME
+                    GEM_ROOT \
+                    RUBYLIB \
+                    RUBYOPT \
+                    RUBY_ENGINE \
+                    RUBY_ROOT \
+                    RUBY_VERSION
+
 do
   unset $ruby_env_var
 done

--- a/jenkins/verify-chefdk.sh
+++ b/jenkins/verify-chefdk.sh
@@ -4,11 +4,17 @@ export PATH=/opt/chefdk/bin:$PATH
 
 # Ensure the calling environment (disapproval look Bundler) does not
 # infect our Ruby environment created by the `chef` cli.
-for ruby_env_var in RUBYOPT \
+for ruby_env_var in _ORIGINAL_GEM_PATH \
                     BUNDLE_BIN_PATH \
                     BUNDLE_GEMFILE \
+                    GEM_HOME \
                     GEM_PATH \
-                    GEM_HOME
+                    GEM_ROOT \
+                    RUBYLIB \
+                    RUBYOPT \
+                    RUBY_ENGINE \
+                    RUBY_ROOT \
+                    RUBY_VERSION
 do
   unset $ruby_env_var
 done


### PR DESCRIPTION
This updates the verify scripts to execute Chef’s RSpec test suite. The verify scripts are executed by the test stage of our CI pipelines. It would also be nice to build this functionality into the Chef package, much like we have for ChefDK (`chef verify --unit`).

__PLEASE NOTE__ - The verify scripts are only used in NEW CI (Manhattan) pipelines. 

/cc @btm @jdmundrawala @adamedx @chef/ociv 

CI Test: http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/4/downstreambuildview/