### PR TITLE
ChefDK 0.5.0.rc omnibus release

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -48,7 +48,7 @@ override :cacerts, version: '2014.08.20'
 
 override :berkshelf,      version: "v3.2.3"
 override :bundler,        version: "1.7.12"
-override :chef,           version: "master"
+override :chef,           version: "12.2.1"
 override :'chef-vault',   version: "v2.4.0"
 
 # TODO: Can we bump default versions in omnibus-software?
@@ -57,14 +57,14 @@ override :libtool,        version: "2.4.2"
 override :libxml2,        version: "2.9.1"
 override :libxslt,        version: "1.1.28"
 
-override :ruby,           version: "2.1.4"
+override :ruby,           version: "2.1.5"
 ######
-# Ruby 2.1.3 is currently not working on windows due to:
-# https://github.com/ffi/ffi/issues/375
-# Enable below once above issue is fixed.
-# override :'ruby-windows', version: "2.1.3"
-# override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
-override :'ruby-windows', version: "2.0.0-p451"
+# Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
+# https://bugs.ruby-lang.org/issues/11033
+# Going to leave 2.1.5 for now since there is a workaround
+override :'ruby-windows', version: "2.1.5"
+override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+#override :'ruby-windows', version: "2.0.0-p451"
 ######
 
 ######
@@ -74,15 +74,16 @@ override :'ruby-windows', version: "2.0.0-p451"
 override :rubygems,       version: "2.4.4"
 ######
 
-override :'test-kitchen', version: "v1.3.1"
+override :'test-kitchen', version: "v1.4.0.rc.1"
+override :'kitchen-vagrant', version: "v0.17.0.rc.1"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"
 
-override :'chef-provisioning', version: "v0.18"
-override :'chef-provisioning-fog', version: "v0.12"
-override :'chef-provisioning-vagrant', version: "v0.8.1"
-override :'chef-provisioning-azure', version: "v0.1"
-override :'chef-provisioning-aws', version: "v0.2.2"
+override :'chef-provisioning', version: "v1.1.0"
+override :'chef-provisioning-fog', version: "v0.13.2"
+override :'chef-provisioning-vagrant', version: "v0.8.3"
+override :'chef-provisioning-azure', version: "v0.3.2"
+override :'chef-provisioning-aws', version: "v1.1.0"
 
 dependency "preparation"
 dependency "chefdk"

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -17,7 +17,7 @@
 name "chef-provisioning-aws"
 default_version "master"
 
-source git: "git://github.com/opscode/chef-provisioning-aws.git"
+source git: "git://github.com/chef/chef-provisioning-aws.git"
 
 if windows?
   dependency "ruby-windows"

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -17,7 +17,7 @@
 name "chef-provisioning-azure"
 default_version "master"
 
-source git: "git://github.com/opscode/chef-provisioning-azure.git"
+source git: "git://github.com/chef/chef-provisioning-azure.git"
 
 if windows?
   dependency "ruby-windows"

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -17,7 +17,7 @@
 name "chef-provisioning-fog"
 default_version "master"
 
-source git: "git://github.com/opscode/chef-provisioning-fog.git"
+source git: "git://github.com/chef/chef-provisioning-fog.git"
 
 if windows?
   dependency "ruby-windows"

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -17,7 +17,7 @@
 name "chef-provisioning-vagrant"
 default_version "master"
 
-source git: "git://github.com/opscode/chef-provisioning-vagrant.git"
+source git: "git://github.com/chef/chef-provisioning-vagrant.git"
 
 if windows?
   dependency "ruby-windows"

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -15,9 +15,9 @@
 #
 
 name "chefdk"
-default_version "0.4.0"
+default_version "master"
 
-source git: "git://github.com/opscode/chef-dk"
+source git: "git://github.com/chef/chef-dk.git"
 
 relative_path "chef-dk"
 
@@ -30,6 +30,7 @@ dependency "chef-vault"
 dependency "foodcritic"
 dependency "ohai"
 dependency "test-kitchen"
+dependency "kitchen-vagrant"
 dependency "chef"
 dependency "openssl-customization"
 
@@ -60,7 +61,7 @@ build do
     'fauxhai'           => '2.2.0',
     'rubocop'           => '0.28.0',
     'knife-spork'       => '1.5.0',
-    'kitchen-vagrant'   => '0.15.0',
+    'winrm-transport'   => '1.0.0',
     'knife-windows'     => '0.8.4',
     # Strainer build is hosed on windows
     # 'strainer'        => '0.15.0',

--- a/config/software/kitchen-vagrant.rb
+++ b/config/software/kitchen-vagrant.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-name "chef-provisioning"
+name "kitchen-vagrant"
 default_version "master"
 
-source git: "git://github.com/chef/chef-provisioning.git"
+source git: "git://github.com/test-kitchen/kitchen-vagrant.git"
 
 if windows?
   dependency "ruby-windows"
@@ -28,14 +28,14 @@ else
 end
 
 dependency "bundler"
-dependency "chef"
+dependency "test-kitchen"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle "install --without development guard test", env: env
 
-  gem "build chef-provisioning.gemspec", env: env
-  gem "install chef-provisioning-*.gem" \
+  gem "build kitchen-vagrant.gemspec", env: env
+  gem "install kitchen-vagrant-*.gem" \
       " --no-ri --no-rdoc", env: env
 end


### PR DESCRIPTION
\cc @chef/client-core 

Before 0.5.0 can be released, I want to pull in the released versions of the test kitchen dependencies and the final (non-rc) version of ChefDK.