### PR TITLE
Update Mac signing identity

### DIFF
--- a/config/projects/angrychef.rb
+++ b/config/projects/angrychef.rb
@@ -39,7 +39,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.angrychef"
-  signing_identity "Developer ID Installer: Opscode Inc. (9NBR9JL2R2)"
+  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
 end
 
 compress :dmg

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -73,7 +73,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.chef"
-  signing_identity "Developer ID Installer: Opscode Inc. (9NBR9JL2R2)"
+  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
 end
 compress :dmg
 

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -101,7 +101,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.chefdk"
-  signing_identity "Developer ID Installer: Opscode Inc. (9NBR9JL2R2)"
+  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
 end
 
 package :msi do

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -56,7 +56,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.push-jobs-client"
-  signing_identity "Developer ID Installer: Opscode Inc. (9NBR9JL2R2)"
+  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
 end
 compress :dmg
 


### PR DESCRIPTION
A couple of notes:

* The new signing identity was already deployed across Manhattan with https://github.com/opscode-cookbooks/opscode-ci/pull/260:
* I've also manually imported the new signing identity into the existing Mac OS X 10.6 and 10.7 builders in OLD CI.

/cc @chef/ociv @sersut @chef/client-engineers 