### PR TITLE
Push Job client updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,13 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 50f19078a3de46bc93b15bd5549264cd1841adb1
+  revision: bd87fe4f6b4d3c82adf67434a34d14c203968f22
   specs:
     omnibus (4.0.0)
-      chef-sugar (~> 2.2)
+      chef-sugar (~> 3.0)
       cleanroom (~> 1.0)
       mixlib-shellout (~> 1.4)
+      mixlib-versioning
       ohai (~> 7.2)
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
@@ -52,7 +53,7 @@ GEM
     celluloid-io (0.16.1)
       celluloid (>= 0.16.0)
       nio4r (>= 1.0.0)
-    chef-sugar (2.5.0)
+    chef-sugar (3.1.0)
     cleanroom (1.0.0)
     dep-selector-libgecode (1.0.2)
     dep_selector (1.0.3)
@@ -61,8 +62,8 @@ GEM
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.6)
-    ffi (1.9.6-x86-mingw32)
+    ffi (1.9.8)
+    ffi (1.9.8-x86-mingw32)
     ffi-yajl (1.4.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
@@ -94,6 +95,7 @@ GEM
     mixlib-shellout (1.6.1-x86-mingw32)
       win32-process (~> 0.7.1)
       windows-pr (~> 1.2.2)
+    mixlib-versioning (1.0.0)
     multi_json (1.11.0)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
@@ -133,7 +135,7 @@ GEM
       retryable
       semverse (~> 1.1)
       varia_model (~> 0.4)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
     rubyntlm (0.4.0)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
@@ -144,7 +146,7 @@ GEM
     solve (1.2.1)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
-    systemu (2.6.4)
+    systemu (2.6.5)
     test-kitchen (1.4.0.rc.1)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -160,10 +162,10 @@ GEM
     varia_model (0.4.0)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 3.0.0)
-    win32-api (1.5.2-x86-mingw32)
+    win32-api (1.5.3-x86-mingw32)
     win32-process (0.7.5)
       ffi (>= 1.0.0)
-    windows-api (0.4.3)
+    windows-api (0.4.4)
       win32-api (>= 1.4.5)
     windows-pr (1.2.4)
       win32-api (>= 1.4.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 3039a4439971ab95e476d02f742bc12a6d0e2bd7
+  revision: ebe47c86eb3368e6d86a183b8162c266b5c52c1d
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -53,10 +53,31 @@ end
 # Software does).
 override :cacerts, version: '2014.08.20'
 
-override :bundler,        version: "1.7.2"
-override :ruby,           version: "1.9.3-p547"
-override :'ruby-windows', version: "1.9.3-p484"
-override :rubygems,       version: "2.4.1"
+override :bundler,        version: "1.7.12"
+override :chef,           version: "12.2.1"
+
+# TODO: Can we bump default versions in omnibus-software?
+override :libedit,        version: "20130712-3.1"
+override :libtool,        version: "2.4.2"
+override :libxml2,        version: "2.9.1"
+override :libxslt,        version: "1.1.28"
+
+override :ruby,           version: "2.1.5"
+######
+# Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
+# https://bugs.ruby-lang.org/issues/11033
+# Going to leave 2.1.5 for now since there is a workaround
+override :'ruby-windows', version: "2.1.5"
+override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
+#override :'ruby-windows', version: "2.0.0-p451"
+######
+
+######
+# rubygems 2.4.5 is not working on windows.
+# See https://github.com/rubygems/rubygems/issues/1120
+# Once this is fixed, we can bump the version
+override :rubygems,       version: "2.4.4"
+######
 
 dependency "preparation"
 dependency "opscode-pushy-client"

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -41,6 +41,18 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
+# As of 27 October 2014, the newest CA cert bundle does not work with AWS's
+# root cert. See:
+# * https://github.com/opscode/chef-dk/issues/199
+# * https://blog.mozilla.org/security/2014/09/08/phasing-out-certificates-with-1024-bit-rsa-keys/
+# * https://forums.aws.amazon.com/thread.jspa?threadID=164095
+# * https://github.com/opscode/omnibus-supermarket/commit/89197026af2931de82cfdc13d92ca2230cced3b6
+#
+# For now we resolve it by using an older version of the cert. This only works
+# if you have this version of the CA bundle stored via S3 caching (which Chef
+# Software does).
+override :cacerts, version: '2014.08.20'
+
 override :bundler,        version: "1.7.2"
 override :ruby,           version: "1.9.3-p547"
 override :'ruby-windows', version: "1.9.3-p484"

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -24,13 +24,7 @@ replace  "opscode-push-jobs-client"
 conflict "opscode-push-jobs-client"
 
 build_iteration 1
-build_version do
-  # Use chef to determine the build version
-  source :git, from_dependency: 'opscode-pushy-client'
-
-  # Output a SemVer compliant version string
-  output_format :semver
-end
+build_version "2.0.0-alpha.1"
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
This PR along with https://github.com/opscode-cookbooks/opscode-ci/pull/265 will allow Push Jobs Client to be built on manhattan.ci.chef.co

/cc @chef/ociv @chef/client-engineers @manderson26 