### PR TITLE
Ruby 1.9.3 on Solaris 10 SPARC fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 4ca326c4ea5dadbd32c700ff3c31cb8b63a9977b
+  revision: 90d51d704369a6ea9828411a4f71ff81138b3b5d
   specs:
     omnibus-software (4.0.0)
 

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -39,6 +39,10 @@ build_retries 3
 fetcher_retries 3
 fetcher_read_timeout 120
 
+# We limit this to 10 workers to eliminate transient timing issues in the
+# way Ruby (and other components) compiles on some more esoteric *nixes.
+workers 10
+
 # Load additional software
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']


### PR DESCRIPTION
Fixes that allow Ruby 1.9.3 to properly compile in Solaris 10 SPARC machines in the Manhattan cluster. See https://github.com/chef/omnibus-software/pull/405 for more details

/cc @chef/ociv @jdmundrawala @btm @thommay @adamedx 
