### PR TITLE
Manhattan-compatible chef-11-stable branch

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -50,17 +50,14 @@ end
 # Software does).
 override :cacerts, version: '2014.08.20'
 
-override :bundler,        version: "1.7.2"
-override :ruby,           version: "2.1.4"
-######
-# Ruby 2.1.3 is currently not working on windows due to:
-# https://github.com/ffi/ffi/issues/375
-# Enable below once above issue is fixed.
-# override :'ruby-windows', version: "2.1.3"
-# override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
-override :'ruby-windows', version: "2.0.0-p451"
-######
-override :rubygems,       version: "2.4.4"
+override :bundler,        version: "1.5.3"
+override :ruby,           version: "1.9.3-p550"
+override :rubygems,       version: "2.1.11"
+
+# Windows
+override :'ruby-windows',             version: "1.9.3-p484"
+override :'ruby-windows-devkit',      version: "4.5.2-20111229-1559"
+override :'ruby-windows-devkit-bash', version: "3.1.23-4-msys-1.0.18"
 
 dependency "preparation"
 dependency "chef"

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -59,6 +59,10 @@ override :'ruby-windows',             version: "1.9.3-p484"
 override :'ruby-windows-devkit',      version: "4.5.2-20111229-1559"
 override :'ruby-windows-devkit-bash', version: "3.1.23-4-msys-1.0.18"
 
+# Chef Release version pinning
+override :chef, version: "11.18.8"
+override :ohai, version: "7.4-stable"
+
 dependency "preparation"
 dependency "chef"
 dependency "shebang-cleanup"


### PR DESCRIPTION
This branch will replace the current `chef-11-stable` branch (which has been tagged for archive purposes as `chef-11-stable-OLD`). This new branch is basically the same as current master with the addition of a few overrides to build the older Ruby toolchain and peg the Chef version to the 11.x series.

Chef 11 builds should use the `chef-11` pipeline on [manhattan.ci.chef.co](http://manhattan.ci.chef.co). This pipeline is identical to the regular `chef` pipeline minus FreeBSD 10. It’s not possible to build Ruby 1.9.3 (the version we ship with Chef 11) on FreeBSD 10. Since FreeBSD 10 didn’t even exist in the OLD CI matrix it’s easiest to just drop it for Chef 11 builds. We can get rid of this pipeline when one of the two following items is true:

* We update the Chef 11 Ruby version to 2.1.x.
* We EOL Chef 11 and stop shipping releases

/cc @chef/ociv @chef/client-engineers 
