### PR TITLE
Change ChefDK default_version to `master`

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -15,7 +15,7 @@
 #
 
 name "chefdk"
-default_version "0.4.0"
+default_version "master"
 
 source git: "git://github.com/opscode/chef-dk"
 


### PR DESCRIPTION
This will ensure our integration/nightly builds:

* Pull in the latest changes from the `chef-dk` gem.
* Contain the proper base version (currently `0.5.0-rc.5`)

When it’s time for release, the ChefDK version should be locked via an override version in the ChefDK project definition:

```ruby
override :chefdk, version: “0.5.0”
```

/cc @chef/ociv @chef/client-engineers @chef/test-driven-infrastructure 
