### PR TITLE
Preping for ChefDK 0.5.0 release

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -34,6 +34,9 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
+# Pinning chefdk version for release
+override :chefdk, version: '0.5.0'
+
 # As of 27 October 2014, the newest CA cert bundle does not work with AWS's
 # root cert. See:
 # * https://github.com/opscode/chef-dk/issues/199
@@ -74,16 +77,16 @@ override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
 override :rubygems,       version: "2.4.4"
 ######
 
-override :'test-kitchen', version: "v1.4.0.rc.1"
-override :'kitchen-vagrant', version: "v0.17.0.rc.1"
+override :'test-kitchen', version: "v1.4.0"
+override :'kitchen-vagrant', version: "v0.17.0"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"
 
-override :'chef-provisioning', version: "v1.1.0"
+override :'chef-provisioning', version: "v1.1.1"
 override :'chef-provisioning-fog', version: "v0.13.2"
 override :'chef-provisioning-vagrant', version: "v0.8.3"
 override :'chef-provisioning-azure', version: "v0.3.2"
-override :'chef-provisioning-aws', version: "v1.1.0"
+override :'chef-provisioning-aws', version: "v1.1.1"
 
 dependency "preparation"
 dependency "chefdk"


### PR DESCRIPTION
I'll need to update to the tagged version instead of just master when performing the release