### PR TITLE
Updating kitchen-vagrant to the latest version

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -75,7 +75,7 @@ override :rubygems,       version: "2.4.4"
 ######
 
 override :'test-kitchen', version: "v1.4.0"
-override :'kitchen-vagrant', version: "v0.17.0"
+override :'kitchen-vagrant', version: "v0.18.0"
 override :yajl,           version: "1.2.1"
 override :zlib,           version: "1.2.8"
 


### PR DESCRIPTION
Includes https://github.com/test-kitchen/kitchen-vagrant/issues/166 which fixes problems users are having with specifying the latest box definitions in their .kitchen.yml