### PR TITLE
Remove chef-provisioning core from driver deps

### DIFF
--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -28,7 +28,6 @@ else
 end
 
 dependency "bundler"
-dependency "chef-provisioning"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -28,7 +28,6 @@ else
 end
 
 dependency "bundler"
-dependency "chef-provisioning"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -29,7 +29,6 @@ end
 
 dependency "bundler"
 dependency "nokogiri"
-dependency "chef-provisioning"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -28,7 +28,6 @@ else
 end
 
 dependency "bundler"
-dependency "chef-provisioning"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
We are now managing the version of chef-provisioning core from chef-dk's
gemspec. The omnibus level dependency was causing us to pull in master
of chef-provisioning, which currently breaks the build due to dependency
conflicts between chef-provisioning and knife-windows

@chef/client-core @chef/chef-provisioning-committers 