### PR TITLE
Ship the Delivery CLI in ChefDK

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -34,6 +34,15 @@ dependency "kitchen-vagrant"
 dependency "chef"
 dependency "openssl-customization"
 
+# Delivery CLI is *nix only ATM
+unless windows?
+  # Delivery CLI
+  dependency "delivery-cli"
+  # We treat Rust as a build-time dep only. See the software definition for
+  # more details.
+  dependency "rust-uninstall"
+end
+
 # The devkit has to be installed after rubygems-customization so the
 # file it installs gets patched.
 dependency "ruby-windows-devkit" if windows?

--- a/config/software/delivery-cli.rb
+++ b/config/software/delivery-cli.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "delivery-cli"
+default_version "master"
+
+source git: "https://github.com/chef/delivery-cli.git"
+
+dependency "openssl"
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # The rust core libraries are dynamicaly linked
+  env['LD_LIBRARY_PATH']            = "#{install_dir}/embedded/lib"
+  env['DYLD_FALLBACK_LIBRARY_PATH'] = "#{install_dir}/embedded/lib:" if mac_os_x?
+
+  command "cargo test -j #{workers}", env: env
+  command "cargo build -j #{workers} --release", env: env
+
+  mkdir "#{install_dir}/bin"
+  copy "#{project_dir}/target/release/delivery", "#{install_dir}/bin/delivery"
+end

--- a/config/software/rust-uninstall.rb
+++ b/config/software/rust-uninstall.rb
@@ -1,0 +1,30 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust-uninstall"
+default_version "0.0.1"
+
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # Until Omnibus has full support for build depedencies (see chef/omnibus#483)
+  # we don't want to ship the Rust and Cargo in our final artifact. Luckily
+  # Rust ships with a nice uninstall script which makes it easy to strip
+  # everything out.
+  command "#{install_dir}/embedded/lib/rustlib/uninstall.sh", env: env
+end

--- a/config/software/rust.rb
+++ b/config/software/rust.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust"
+default_version "2015-04-29"
+
+if mac_os_x?
+  host_triple = "apple-darwin"
+
+  version "1.0.0" do
+    source md5: "45bbb4f6d4502c2af870e6a74033a707"
+  end
+  version "2015-04-29" do
+    source md5: "33914f7ac0dab1dbc90d279dff8d8e2b"
+  end
+else
+  host_triple = "unknown-linux-gnu"
+
+  version "1.0.0" do
+    source md5: "bf108fe44d5f05507418c00ce7a08f3e"
+  end
+  version "2015-04-29" do
+    source md5: "47f8dbf39f2ecf8a67119551ea6dcefd"
+  end
+end
+
+# Nightly versions of Rust have a slightly different URL structure and
+# package name
+if version =~ /\d{4}-\d{2}-\d{2}/
+  source url: "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-#{host_triple}.tar.gz"
+  relative_path "rust-nightly-x86_64-#{host_triple}"
+else
+  source url: "https://static.rust-lang.org/dist/rust-#{version}-x86_64-#{host_triple}.tar.gz"
+  relative_path "rust-#{version}-x86_64-#{host_triple}"
+end
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./install.sh" \
+          " --prefix=#{install_dir}/embedded" \
+          " --components=rustc,cargo" \
+          " --verbose", env: env
+end

--- a/package-scripts/chefdk/postinst
+++ b/package-scripts/chefdk/postinst
@@ -28,7 +28,7 @@ fi
 
 # We test for the presence of /usr/bin/chef-client to know if this script succeeds,
 # so chef-client must appear as the last item here.
-binaries="chef chef-solo chef-apply chef-shell knife shef ohai berks chef-zero fauxhai foodcritic kitchen rubocop strain strainer chef-client"
+binaries="berks chef chef-apply chef-shell chef-solo chef-zero delivery fauxhai foodcritic kitchen knife ohai shef strain strainer rubocop chef-client"
 
 # rm -f before ln -sf is required for solaris 9
 for binary in $binaries; do

--- a/package-scripts/chefdk/postrm
+++ b/package-scripts/chefdk/postrm
@@ -18,7 +18,7 @@ else
 fi
 
 cleanup_symlinks() {
-  binaries="chef chef-solo chef-apply chef-shell knife shef ohai berks chef-zero fauxhai foodcritic kitchen rubocop strain strainer chef-client"
+  binaries="berks chef chef-apply chef-shell chef-solo chef-zero delivery fauxhai foodcritic kitchen knife ohai shef strain strainer rubocop chef-client"
   for binary in $binaries; do
     rm -f $PREFIX/bin/$binary
   done


### PR DESCRIPTION
After some discussions with the Delivery team this feels like the right place to package the `delivery` binary. From an end-user perspective it's delightful to not have to install yet another package to get the delivery-cli on your workstation. On the build node side most jobs that the delivery-cli executes rely on the other tools that ship in ChefDK.

A couple of things to note:

* This is *nix ONLY ATM. The Delivery team will work on integrating the Windows support :soon:.
* Rust is needed as a build dependency only. Until the Omnibus framework has first class support for build deps (please see https://github.com/chef/omnibus/issues/483) we just remove Rust (and Cargo) from the install dir before running the health check or creating the final package.

Assuming everyone is happy with this approach I'll also update `chef verify` to be aware of the `delivery` binary.

/cc @chef/ociv @chef/delivery @chef/client-core @fnichol @tyler-ball @cwebberOps @adamhjk 
