### PR TITLE
Update to newest omnibus-software

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 6cf2b128d8e820c15a6e309bc4fd37cd0d0e1c54
+  revision: 8d94cf48688cebb7ea6e6690df20501379a64839
   specs:
     omnibus-software (4.0.0)
 


### PR DESCRIPTION
@chef/omnibus-maintainers 
This pulls in the latest omnibus-software and fixes the push-client build

Push build passes, chef client still running
http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/72/
http://manhattan.ci.chef.co/job/push-jobs-client-trigger-ad_hoc/24/downstreambuildview/