### PR TITLE
Build Chef from master in ChefDK

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -46,9 +46,10 @@ end
 # Software does).
 override :cacerts, version: '2014.08.20'
 
+# Uncomment to pin the chef version
+# override :chef,           version: "12.3.0"
 override :berkshelf,      version: "v3.2.4"
 override :bundler,        version: "1.7.12"
-override :chef,           version: "12.3.0"
 override :'chef-vault',   version: "v2.4.0"
 
 # TODO: Can we bump default versions in omnibus-software?


### PR DESCRIPTION
We have to at least build from https://github.com/chef/chef/commit/16163d77b84016229a0b285dada12fbc59b80565 because the omnibus build now expects Chef to have a `rake install_components` task. Building from master makes more sense for nightlies, anyway.

@chef/omnibus-maintainers @jdmundrawala @tyler-ball @lamont-granquist 