### PR TITLE
Update push to use master of chef

### DIFF
--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -48,7 +48,8 @@ end
 override :cacerts, version: '2014.08.20'
 
 override :bundler,        version: "1.7.12"
-override :chef,           version: "12.2.1"
+# Uncomment to pin the chef version
+#override :chef,           version: "12.2.1"
 override :ruby,           version: "2.1.6"
 ######
 # Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working


### PR DESCRIPTION
This should fix the build failures for push

http://manhattan.ci.chef.co/job/push-jobs-client-build/90/

There is still some work to do because we require 11.12.2 in some places inside of the push client.