### PR TITLE
Bump chef-vault to 2.6.1

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -50,7 +50,7 @@ override :cacerts, version: '2014.08.20'
 # override :chef,           version: "12.3.0"
 override :berkshelf,      version: "v3.2.4"
 override :bundler,        version: "1.7.12"
-override :'chef-vault',   version: "v2.4.0"
+override :'chef-vault',   version: "v2.6.1"
 
 # TODO: Can we bump default versions in omnibus-software?
 override :libedit,        version: "20130712-3.1"

--- a/config/software/chef-vault.rb
+++ b/config/software/chef-vault.rb
@@ -15,7 +15,7 @@
 #
 
 name "chef-vault"
-default_version "v2.2.4"
+default_version "v2.6.1"
 
 source git: "git://github.com/Nordstrom/chef-vault.git"
 


### PR DESCRIPTION
Chef Vault 2.6.1 includes https://github.com/Nordstrom/chef-vault/pull/172 which will help us with some dependency issues we've been causing ourselves in ChefDK (https://github.com/chef/knife-windows/issues/236)

@chef/client-core 
@chef/omnibus-maintainers 