### PR TITLE
Bump bundler to 1.10.0 for ChefDK

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,7 +49,7 @@ override :cacerts, version: '2014.08.20'
 # Uncomment to pin the chef version
 # override :chef,           version: "12.3.0"
 override :berkshelf,      version: "v3.2.4"
-override :bundler,        version: "1.7.12"
+override :bundler,        version: "1.10.0"
 override :'chef-vault',   version: "v2.6.1"
 
 # TODO: Can we bump default versions in omnibus-software?


### PR DESCRIPTION
I don't know for certain (because the bug is intermittent), but I'm hoping this fixes the intermittent errors we see like:

```
C:/opscode/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:762:in `block in _resort!': undefined method `name' for nil:NilClass (NoMethodError)
```

Note however, that this change requires https://github.com/chef/chef/commit/8e3e5248ba0d2fbae7aba15129b635ee6c2587c6 because installing gems inside a bundler'd ruby doesn't work in this version of bundler.

Thoughts?

@chef/client-core 
