### PR TITLE
Branching 0.6.0 release to 0.6.1 - only includes fix for SSL broken on Windows, fixes https://github.com/chef/chef-dk/issues/420

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 01ead51b00fb659e239eceb85b4c19806a87403b
+  revision: 5ed5e5bfd7c99de66c46aede110cefe1d5d997ac
   specs:
     omnibus (4.0.0)
       chef-sugar (~> 3.0)
@@ -96,7 +96,7 @@ GEM
     mixlib-shellout (1.6.1-x86-mingw32)
       win32-process (~> 0.7.1)
       windows-pr (~> 1.2.2)
-    mixlib-versioning (1.0.0)
+    mixlib-versioning (1.1.0)
     multi_json (1.11.0)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
@@ -163,7 +163,7 @@ GEM
     varia_model (0.4.0)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 3.0.0)
-    win32-api (1.5.3-x86-mingw32)
+    win32-api (1.5.3-universal-mingw32)
     win32-process (0.7.5)
       ffi (>= 1.0.0)
     windows-api (0.4.4)
@@ -196,3 +196,6 @@ DEPENDENCIES
   omnibus-software!
   test-kitchen (~> 1.4.0.rc.1)
   winrm-transport (~> 1.0)
+
+BUNDLED WITH
+   1.10.0

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -34,6 +34,12 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
+# Windows machines started failing all SSL requests.  This is because the ssl_env_hack
+# require was occuring after `DEFAULT_CERT_STORE.set_default_paths` was ran from
+# openssl/ssl.rb.  This meant the DEFAULT_CERT_STORE was not pointing at our
+# packaged cacert.pem file.
+override :chefdk, version: '0.6.1'
+
 # As of 27 October 2014, the newest CA cert bundle does not work with AWS's
 # root cert. See:
 # * https://github.com/opscode/chef-dk/issues/199

--- a/config/software/chef-provisioning-aws.rb
+++ b/config/software/chef-provisioning-aws.rb
@@ -32,9 +32,9 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  #bundle "install --without development", env: env
 
   gem "build chef-provisioning-aws.gemspec", env: env
   gem "install chef-provisioning-aws-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc --conservative", env: env
 end

--- a/config/software/chef-provisioning-azure.rb
+++ b/config/software/chef-provisioning-azure.rb
@@ -32,9 +32,9 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  #bundle "install --without development", env: env
 
   gem "build chef-provisioning-azure.gemspec", env: env
   gem "install chef-provisioning-azure-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc  --conservative", env: env
 end

--- a/config/software/chef-provisioning-fog.rb
+++ b/config/software/chef-provisioning-fog.rb
@@ -33,9 +33,9 @@ dependency "nokogiri"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  #bundle "install --without development", env: env
 
   gem "build chef-provisioning-fog.gemspec", env: env
   gem "install chef-provisioning-fog-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc --conservative", env: env
 end

--- a/config/software/chef-provisioning-vagrant.rb
+++ b/config/software/chef-provisioning-vagrant.rb
@@ -32,9 +32,9 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  #bundle "install --without development", env: env
 
   gem "build chef-provisioning-vagrant.gemspec", env: env
   gem "install chef-provisioning-vagrant-*.gem" \
-      " --no-ri --no-rdoc", env: env
+      " --no-ri --no-rdoc  --conservative", env: env
 end

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -62,7 +62,7 @@ build do
     'rubocop'           => '0.28.0',
     'knife-spork'       => '1.5.0',
     'winrm-transport'   => '1.0.0',
-    'knife-windows'     => '0.8.4',
+    'knife-windows'     => '0.8.5',
     # Strainer build is hosed on windows
     # 'strainer'        => '0.15.0',
   }.each do |name, version|

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -61,7 +61,10 @@ build do
       # if it's not already set
       source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
       File.open(source_openssl_rb, "r+") do |f|
+        unpatched_openssl_rm = f.read
+        f.rewind
         f.write("\nrequire 'ssl_env_hack'\n")
+        f.write(unpatched_openssl_rm)
       end
     end
   end

--- a/config/software/openssl-customization.rb
+++ b/config/software/openssl-customization.rb
@@ -60,7 +60,7 @@ build do
       # to pick up our script which find the CA bundle in omnibus installations and points SSL_CERT_FILE to it
       # if it's not already set
       source_openssl_rb = File.join(embedded_ruby_lib_dir, "openssl.rb")
-      File.open(source_openssl_rb, "a") do |f|
+      File.open(source_openssl_rb, "r+") do |f|
         f.write("\nrequire 'ssl_env_hack'\n")
       end
     end


### PR DESCRIPTION
Fixes https://github.com/chef/chef-dk/issues/420

\cc @danielsdeleo @jdmundrawala @fnichol 

I'm not actually going to merge this to master - I'll release out of this branch and tag this in Github.  I created a [6-stable](https://github.com/chef/chef-dk/tree/6-stable) branch in chef-dk off of the old 6.0.0 release SHA.  I'm doing all this to ensure that the _only_ change in 0.6.1 is the fix to `require` ordering.

TODOs:
- [x] Add tests in `chef verify` to catch regressions of this
- [ ] Move the change into master so it is included in 0.7.0