### PR TITLE
Updating chef-provisioning-aws to latest version 1.2.1

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -86,7 +86,7 @@ override :zlib,           version: "1.2.8"
 override :'chef-provisioning-fog', version: "v0.13.2"
 override :'chef-provisioning-vagrant', version: "v0.8.3"
 override :'chef-provisioning-azure', version: "v0.3.2"
-override :'chef-provisioning-aws', version: "v1.1.1"
+override :'chef-provisioning-aws', version: "v1.2.1"
 
 dependency "preparation"
 dependency "chefdk"


### PR DESCRIPTION
In preparation for 0.7.0 release.

\cc @jdmundrawala @jkeiser @danielsdeleo 