### PR TITLE
Move to knife-windows 1.0.0.rc.1 (for nightlies and the next RC)

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -63,7 +63,7 @@ build do
     'rubocop'           => '0.31.0',
     'knife-spork'       => '1.5.0',
     'winrm-transport'   => '1.0.2',
-    'knife-windows'     => '0.8.5',
+    'knife-windows'     => '1.0.0.rc.1',
     # Strainer build is hosed on windows
     # 'strainer'        => '0.15.0',
   }.each do |name, version|


### PR DESCRIPTION
@jaym, @ksubrama, @tyler-ball 

The "nightlies" that we're producing still have knife-windows 0.8.5 in them because the commit for knife-windows=1.0.0.rc.0 was in the tball/070rc branch. We released knife-windows=1.0.0.rc.1 today and need to test https://github.com/chef/chef-dk/issues/411.