### PR TITLE
Unbreak build

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -51,7 +51,7 @@ end
 override :cacerts, version: '2014.08.20'
 
 override :bundler,        version: "1.7.2"
-override :ruby,           version: "2.2.2"
+override :ruby,           version: "2.1.6"
 ######
 # Ruby 2.1.3 is currently not working on windows due to:
 # https://github.com/ffi/ffi/issues/375

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -65,6 +65,7 @@ override :rubygems,       version: "2.4.4"
 # Chef Release version pinning
 #override :chef, version: "12.4.1"
 #override :ohai, version: "8.5.0"
+override :'openssl-windows', version: '1.0.0r'
 
 dependency "preparation"
 dependency "chef"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -60,7 +60,7 @@ override :libtool,        version: "2.4.2"
 override :libxml2,        version: "2.9.1"
 override :libxslt,        version: "1.1.28"
 
-override :ruby,           version: "2.2.2"
+override :ruby,           version: "2.1.6"
 ######
 # Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
 # https://bugs.ruby-lang.org/issues/11033

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -50,7 +50,7 @@ override :cacerts, version: '2014.08.20'
 override :bundler,        version: "1.7.12"
 # Uncomment to pin the chef version
 #override :chef,           version: "12.2.1"
-override :ruby,           version: "2.2.2"
+override :ruby,           version: "2.1.6"
 ######
 # Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
 # https://bugs.ruby-lang.org/issues/11033


### PR DESCRIPTION
On Windows, OpenSSL 1.0.1x is causing problems with Ruby 2.0.x. Reverting back to OpenSSL 1.0.0x.

On *nix, ruby 2.2.2 is causing multiple different problems. We're seeing higher than normal network timeouts (talking to what looks like localhost) and segfaults.

I'd like to at least unbreak the build and then we can decide how we are going to track down all the failures with ruby 2.2.2. I suspect that we need to rebuild ruby while openssl 1.0.1x is available instead of droppping it in for the windows stuff.

cc @thommay @lamont-granquist 