### PR TITLE
For OS X, move symlink to an 10.11 friendly location

### DIFF
--- a/package-scripts/chef/postinst
+++ b/package-scripts/chef/postinst
@@ -21,6 +21,11 @@ error_exit()
   exit 1
 }
 
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
 is_smartos()
 {
   uname -v | grep "^joyent" 2>&1 >/dev/null
@@ -28,6 +33,9 @@ is_smartos()
 
 if is_smartos; then
     PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
+    mkdir -p "$PREFIX/bin"
 else
     PREFIX="/usr"
 fi

--- a/package-scripts/chef/postrm
+++ b/package-scripts/chef/postrm
@@ -11,8 +11,15 @@ is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
 if is_smartos; then
     PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
 else
     PREFIX="/usr"
 fi


### PR DESCRIPTION
This patch will allow the Chef Omnibus installer to run correctly on 10.11. It is reverse compatible with prior OS X versions as /usr/local/bin is in the search path.