### PR TITLE
Use Knife Windows 0.8.x

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -48,6 +48,7 @@ override :cacerts,        version: '2014.08.20'
 
 # Uncomment to pin the chef version
 override :chef,           version: "12.4.1"
+override :ohai,           version: '8.5.0'
 override :chefdk,         version: '0.7.0.rc.3'
 
 override :berkshelf,      version: "v3.2.4"

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -63,7 +63,7 @@ build do
     'rubocop'           => '0.31.0',
     'knife-spork'       => '1.5.0',
     'winrm-transport'   => '1.0.2',
-    'knife-windows'     => '1.0.0.rc.1',
+    'knife-windows'     => '0.8.6.rc.0',
     # Strainer build is hosed on windows
     # 'strainer'        => '0.15.0',
   }.each do |name, version|


### PR DESCRIPTION
We've modified knife-windows to use winrm 1.3.x so that it does not conflict with chef-provisioning.

cc @adamedx @ksubrama @tyler-ball @fnichol @randomcamel 