### PR TITLE
Preping for ChefDK 0.7.0.rc.4 release

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -49,7 +49,7 @@ override :cacerts,        version: '2014.08.20'
 # Uncomment to pin the chef version
 override :chef,           version: "12.4.1"
 override :ohai,           version: '8.5.0'
-override :chefdk,         version: '0.7.0.rc.3'
+override :chefdk,         version: '0.7.0.rc.4'
 
 override :berkshelf,      version: "v3.2.4"
 override :bundler,        version: "1.10.0"


### PR DESCRIPTION
\cc @jaym @ksubrama 

The only difference between this and RC3 is the inclusion of knife-windows 0.8.6.rc.0