### PR TITLE
Temporarily disable functional tests on Windows

### DIFF
--- a/jenkins/verify-chef.bat
+++ b/jenkins/verify-chef.bat
@@ -45,4 +45,4 @@ SET PATH=C:\opscode\%PROJECT_NAME%\bin;C:\opscode\%PROJECT_NAME%\embedded\bin;%P
 
 REM ; Test against the appbundle'd Chef
 cd c:\opscode\%PROJECT_NAME%\embedded\apps\chef
-call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional spec/unit
+call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/unit


### PR DESCRIPTION
Per @jaym, this is to test a working theory that the functional test suite is corrupting the Jenkins service.