### PR TITLE
Override windows builds to x86 for now

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -29,7 +29,7 @@
 # use_git_caching false
 
 # For now, override windows builds to x86
-windows_arch :x86
+windows_arch   ENV['OMNIBUS_WINDOWS_ARCH'] || :x86
 
 # Enable S3 asset caching
 # ------------------------------

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -28,6 +28,9 @@
 # ------------------------------
 # use_git_caching false
 
+# For now, override windows builds to x86
+windows_arch :x86
+
 # Enable S3 asset caching
 # ------------------------------
 use_s3_caching true


### PR DESCRIPTION
Changed windows build target (windows_arch) to default to Ohai architecture (in omnibus repo).
This change overrides that default to x86 for now.

@adamedx @ksubrama @schisamo 