### PR TITLE
Update knife-spork to 1.6.1

### DIFF
--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -61,7 +61,7 @@ build do
     'chefspec'          => '4.3.0',
     'fauxhai'           => '2.3.0',
     'rubocop'           => '0.31.0',
-    'knife-spork'       => '1.6.0',
+    'knife-spork'       => '1.6.1',
     'winrm-transport'   => '1.0.2',
     'knife-windows'     => '0.8.6',
     # Strainer build is hosed on windows

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -61,7 +61,7 @@ build do
     'chefspec'          => '4.3.0',
     'fauxhai'           => '2.3.0',
     'rubocop'           => '0.31.0',
-    'knife-spork'       => '1.5.0',
+    'knife-spork'       => '1.6.0',
     'winrm-transport'   => '1.0.2',
     'knife-windows'     => '0.8.6',
     # Strainer build is hosed on windows


### PR DESCRIPTION
Updating the bundled version of the knife-spork gem to the new 1.6.0 release.