### PR TITLE
Fix broken builds

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -26,8 +26,8 @@
 
 # Windows architecture defaults - set to x86 unless otherwise specified.
 # ------------------------------
-windows_arch   %w{x86 x64}.include?(ENV['OMNIBUS_WINDOWS_ARCH'].downcase) ?
-                ENV['OMNIBUS_WINDOWS_ARCH'].donwcase.to_sym : :x86
+windows_arch   %w{x86 x64}.include?((ENV['OMNIBUS_WINDOWS_ARCH'] || '').downcase) ?
+                ENV['OMNIBUS_WINDOWS_ARCH'].downcase.to_sym : :x86
 
 # Disable git caching
 # ------------------------------


### PR DESCRIPTION
Builds are broken because `OMNIBUS_WINDOWS_ARCH` is not set,
so `ENV[OMNIBUS_WINDOWS_ARCH]` returns nil