### PR TITLE
Chef#462: Move warnings from shell-init on Windows out of stdout

### DIFF
--- a/files/rubygems-customization/windows/operating_system.rb
+++ b/files/rubygems-customization/windows/operating_system.rb
@@ -32,8 +32,8 @@ module Gem
     else
       old_home = File.join(Gem.user_home, '.chefdk')
       if File.exists?(old_home)
-        Gem.ui.say <<-EOF
-        Warning:
+        Gem.ui.alert_warning <<-EOF
+
         ChefDK now defaults to using #{default_home} instead of #{old_home}.
         Since #{old_home} exists on your machine, ChefDK will continue
         to make use of it. Please set the environment variable CHEFDK_HOME


### PR DESCRIPTION
This addresses #462. The issue is that warnings are going to stdout, which users pipe to a command to be executed, and of course the warnings themselves are not valid commands (or if they are, they certainly aren't doing anything the user wants).

The fix is to not output the warning to stdout. This is accomplished by using `Gem.ui.alert_warning` instead of `Gem.ui.say`. I've tested this on Windows and it has the desired affect -- the warning output still appears, but the output of `chef shell init powershell` can be piped to a command for execution (e.g. `iex`) and the command executes succssfully with no errors.