### PR TITLE
update to bundler 1.10.6 which fixes parallel gem installations that …

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -43,7 +43,7 @@ override :chefdk,         version: '0.7.0'
 # branch we made that pins the dependency until its fixed
 # https://github.com/berkshelf/berkshelf/issues/1448
 override :berkshelf,      version: "3.2.4-plus-lock-celluloid", source: { git: "git://github.com/danielsdeleo/berkshelf" }
-override :bundler,        version: "1.10.0"
+override :bundler,        version: "1.10.6"
 override :'chef-vault',   version: "v2.6.1"
 
 # TODO: Can we bump default versions in omnibus-software?


### PR DESCRIPTION
…were broken in earlier 1.10.x versions (see bundler/bundler#3799)

I ran into problems when `bundle install --jobs=16` in this project:
https://github.com/tknerr/sample-toplevel-cookbook

This worked before with ChefDK 0.6.0 / bundler 1.7.12

Now with ChefDK 0.7.0 shipping with bundler 1.10.0 the above `bundle install --jobs=16` reproducibly fails. Updating to bundler 1.10.6 makes it work again.
