### PR TITLE
ChefDK#456: Fix ChefDK installation on OS X El Capitan

### DIFF
--- a/package-scripts/chefdk/postinst
+++ b/package-scripts/chefdk/postinst
@@ -15,6 +15,11 @@ error_exit()
   exit 1
 }
 
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
 is_smartos()
 {
   uname -v | grep "^joyent" 2>&1 >/dev/null
@@ -22,6 +27,9 @@ is_smartos()
 
 if is_smartos; then
     PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
+    mkdir -p "$PREFIX/bin"
 else
     PREFIX="/usr"
 fi

--- a/package-scripts/chefdk/postrm
+++ b/package-scripts/chefdk/postrm
@@ -7,12 +7,19 @@
 #   this programming language.  do not touch.
 # - if you are under 40, get peer review from your elders.
 
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
 is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
 if is_smartos; then
     PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
 else
     PREFIX="/usr"
 fi


### PR DESCRIPTION
This is the same fix applied to chef on
https://github.com/chef/omnibus-chef/pull/439