### PR TITLE
Update rubygems to 2.4.7 to resolve CVE-2015-3900

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -42,7 +42,7 @@ override :bundler,        version: "1.7.2"
 override :ruby,           version: "2.1.6"
 
 override :'ruby-windows', version: "2.0.0-p645"
-override :rubygems,       version: "2.4.4"
+override :rubygems,       version: "2.4.7"
 
 # Chef Release version pinning
 override :chef, version: ENV['CHEF_VERSION'] || "master"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -60,10 +60,7 @@ override :'openssl-windows', version: "1.0.1m"
 ######
 
 ######
-# rubygems 2.4.5 is not working on windows.
-# See https://github.com/rubygems/rubygems/issues/1120
-# Once this is fixed, we can bump the version
-override :rubygems,       version: "2.4.4"
+override :rubygems,       version: "2.4.7"
 ######
 
 override :'test-kitchen', version: "v1.4.2"

--- a/config/projects/push-jobs-client.rb
+++ b/config/projects/push-jobs-client.rb
@@ -52,10 +52,7 @@ override :'ruby-windows-devkit', version: "4.7.2-20130224-1151"
 override :libzmq, version: "4.0.5"
 
 ######
-# rubygems 2.4.5 is not working on windows.
-# See https://github.com/rubygems/rubygems/issues/1120
-# Once this is fixed, we can bump the version
-override :rubygems,       version: "2.4.4"
+override :rubygems,       version: "2.4.7"
 ######
 
 dependency "preparation"


### PR DESCRIPTION
[CVE-2015-3900](http://blog.rubygems.org/2015/05/14/CVE-2015-3900.html)

Note:  do not merge yet, we need to evaluate if rubygems 2.4.7 resolves the problem reported in https://github.com/rubygems/rubygems/issues/1120