### PR TITLE
Update Bundler to 1.10.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 5e806ee021fc3eb68a65126f4a217d4f2076d5a5
+  revision: 4fbd8e7e1e501e3cb99ba7f34634444523f9f266
   specs:
     omnibus (4.1.0)
       aws-sdk (~> 2)

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -38,7 +38,7 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :bundler,        version: "1.7.2"
+override :bundler,        version: "1.10.6"
 override :ruby,           version: "2.1.6"
 
 override :'ruby-windows', version: "2.0.0-p645"


### PR DESCRIPTION
The 64bit windows builds are running into issues with bundler 1.7. Looks like they were fixed in bundler 1.9.3 (it may have been me, i can't tell).
cc @chefsalim @ksubrama  @thommay @adamedx

also, + @danielsdeleo @tyler-ball since i'm including chefdk as well