### PR TITLE
Version ChefDK with a static version number

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -20,10 +20,7 @@ maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 
 build_iteration 1
-build_version do
-  source :git, from_dependency: 'chefdk'
-  output_format :semver
-end
+build_version '0.8.0'
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
Using a static version will make it easier to promote binary artifacts. However, it comes with the cost of having to managing bumping the version as part of the normal development cycle.

/cc @chef/engineering-services @jkeiser @ksubrama @jaym
