### PR TITLE
Bump rubygems to 2.4.8 in Chef

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus', github: 'chef/omnibus'
-gem 'omnibus-software', github: 'chef/omnibus-software'
+gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'jdm/rubygems'
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus', github: 'chef/omnibus'
-gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'jdm/rubygems'
+gem 'omnibus-software', github: 'chef/omnibus-software'
 
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,16 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 5d2d0f9ffdc9d3997359ceeb447c958bd3bd014f
+  revision: 4ef6442661c50e0702149e4860cdb211a5ac346c
+  branch: jdm/rubygems
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 41cfeee13cdb77815e5c03fc4ae012419d2bedde
+  revision: 5e806ee021fc3eb68a65126f4a217d4f2076d5a5
   specs:
-    omnibus (4.0.0)
+    omnibus (4.1.0)
+      aws-sdk (~> 2)
       chef-sugar (~> 3.0)
       cleanroom (~> 1.0)
       mixlib-shellout (~> 2.0)
@@ -16,12 +18,17 @@ GIT
       ohai (~> 8.0)
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
-      uber-s3
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
+    aws-sdk (2.1.18)
+      aws-sdk-resources (= 2.1.18)
+    aws-sdk-core (2.1.18)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.1.18)
+      aws-sdk-core (= 2.1.18)
     berkshelf (3.2.4)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -54,6 +61,9 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    chef-config (12.5.0.alpha.1)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
     chef-sugar (3.1.1)
     cleanroom (1.0.0)
     dep-selector-libgecode (1.0.2)
@@ -76,6 +86,8 @@ GEM
     hitimes (1.2.2-x86-mingw32)
     httpclient (2.6.0.1)
     ipaddress (0.8.0)
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
     json (1.8.3)
     kitchen-vagrant (0.17.0)
       test-kitchen (~> 1.4)
@@ -91,12 +103,11 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
     mixlib-log (1.6.0)
-    mixlib-shellout (2.1.0)
-    mixlib-shellout (2.1.0-universal-mingw32)
+    mixlib-shellout (2.2.0)
+    mixlib-shellout (2.2.0-universal-mingw32)
       win32-process (~> 0.7.5)
-      windows-pr (~> 1.2.4)
     mixlib-versioning (1.1.0)
-    multi_json (1.11.1)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
@@ -106,7 +117,8 @@ GEM
     nori (2.6.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.5.1)
+    ohai (8.6.0)
+      chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -158,19 +170,12 @@ GEM
     thor (0.19.1)
     timers (4.0.1)
       hitimes
-    uber-s3 (0.1.1)
     uuidtools (2.1.5)
     varia_model (0.4.0)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 3.0.0)
-    win32-api (1.5.3-universal-mingw32)
     win32-process (0.7.5)
       ffi (>= 1.0.0)
-    windows-api (0.4.4)
-      win32-api (>= 1.4.5)
-    windows-pr (1.2.4)
-      win32-api (>= 1.4.5)
-      windows-api (>= 0.4.0)
     winrm (1.3.3)
       builder (>= 2.1.2)
       gssapi (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 4ef6442661c50e0702149e4860cdb211a5ac346c
+  revision: f74a6b9ec4dabd1f9e81a4b73aac1f6b55c1f2fc
   branch: jdm/rubygems
   specs:
     omnibus-software (4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: f74a6b9ec4dabd1f9e81a4b73aac1f6b55c1f2fc
-  branch: jdm/rubygems
+  revision: 3637ca2c30b0793f9db657ab61a5e776307d63ff
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -42,7 +42,11 @@ override :bundler,        version: "1.7.2"
 override :ruby,           version: "2.1.6"
 
 override :'ruby-windows', version: "2.0.0-p645"
-override :rubygems,       version: "2.4.4"
+if windows?
+  override :rubygems,       version: "api-platform"
+else
+  override :rubygems,       version: "2.4.8"
+end
 
 # Chef Release version pinning
 override :chef, version: ENV['CHEF_VERSION'] || "master"

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -43,7 +43,7 @@ override :ruby,           version: "2.1.6"
 
 override :'ruby-windows', version: "2.0.0-p645"
 if windows?
-  override :rubygems,       version: "api-platform"
+  override :rubygems,       version: "jdm/2.4.8-patched"
 else
   override :rubygems,       version: "2.4.8"
 end


### PR DESCRIPTION
This will need to be updated to point at master once https://github.com/chef/omnibus-software/pull/479 is merged