### PR TITLE
version Chef with a static version number

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -20,13 +20,7 @@ maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 
 build_iteration 1
-build_version do
-  # Use chef to determine the build version
-  source :git, from_dependency: 'chef'
-
-  # Output a SemVer compliant version string
-  output_format :semver
-end
+build_version '12.5.0'
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
Using a static version will make it easier to promote binary artifacts. However, it comes with the cost of having to managing bumping the version as part of the normal development cycle.

This moves us to use the same, modern version numbering scheme we are using with ChefDK: `MAJOR.MINOR.PATCH+YYYYMMDDHHMMSS`.

/cc @jkeiser @chef/client-core @adamedx @irvingpop