### PR TITLE
Fine tune the library symbol versions a little more for u5+

### DIFF
--- a/files/mapfiles/solaris
+++ b/files/mapfiles/solaris
@@ -1,6 +1,19 @@
 $mapfile_version 2
+DEPEND_VERSIONS libnsl.so {
+  ALLOW = SUNW_1.1;
+  ALLOW = SUNWprivate_1.1;
+};
+DEPEND_VERSIONS libsocket.so {
+  ALLOW = SUNW_1.4;
+  ALLOW = SUNWprivate_1.1;
+};
+DEPEND_VERSIONS libdl.so {
+  ALLOW = SUNW_1.22.1;
+  ALLOW = SUNW_1.4;
+  ALLOW = SUNWprivate_1.1;
+};
 DEPEND_VERSIONS libc.so {
   ALLOW = SUNW_1.22.1;
-  ALLOW = SUNW_1.1;
+  ALLOW = SUNW_1.4;
   ALLOW = SUNWprivate_1.1;
 };


### PR DESCRIPTION
@chef/solaris @chef/engineering-services 
@jblaine @markgibbons

Fixes https://github.com/chef/chef/issues/3505