### PR TITLE
Don’t prematurely bump Chef and ChefDK build versions

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -20,7 +20,7 @@ maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 
 build_iteration 1
-build_version '12.5.0'
+build_version '12.4.3'
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"

--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -20,7 +20,7 @@ maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 
 build_iteration 1
-build_version '0.9.0'
+build_version '0.8.0'
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
We want integration build versions of `0.8.0+YYYYMMDDHHMMSS` so upgrades to `0.9.0` work correctly.

/cc @chef/engineering-services @jkeiser @jaym @adamedx 