### PR TITLE
Update berks to 4.0

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -35,7 +35,7 @@ end
 override :chef,           version: "master"
 override :ohai,           version: "master"
 
-override :berkshelf,      version: "v3.3.0"
+override :berkshelf,      version: "v4.0.0"
 override :bundler,        version: "1.10.6"
 override :'chef-vault',   version: "v2.6.1"
 


### PR DESCRIPTION
The only breaking change in Berks 4 is to drop support for Ruby 1.9.
Using this version gets us all the versions of dependencies we need to
fix this error:

```
Faraday::Error:
       :gzip is not registered on Faraday::Response
```