### PR TITLE
Add Fast MSI support to ChefDK

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 3e59997f785ac9a7df177a7638265f6765d1d4b1
+  revision: c078b22c0b77b96b00e4f529af7466c919d25529
   specs:
-    omnibus (4.1.0)
+    omnibus (5.0.0)
       aws-sdk (~> 2)
       chef-sugar (~> 3.0)
       cleanroom (~> 1.0)
@@ -22,12 +22,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.1.30)
-      aws-sdk-resources (= 2.1.30)
-    aws-sdk-core (2.1.30)
+    aws-sdk (2.1.36)
+      aws-sdk-resources (= 2.1.36)
+    aws-sdk-core (2.1.36)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.1.30)
-      aws-sdk-core (= 2.1.30)
+    aws-sdk-resources (2.1.36)
+      aws-sdk-core (= 2.1.36)
     berkshelf (3.2.4)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -101,9 +101,10 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
     mixlib-log (1.6.0)
-    mixlib-shellout (2.2.2)
-    mixlib-shellout (2.2.2-universal-mingw32)
+    mixlib-shellout (2.2.3)
+    mixlib-shellout (2.2.3-universal-mingw32)
       win32-process (~> 0.8.2)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.1.0)
     multi_json (1.11.2)
     multipart-post (2.0.0)
@@ -201,4 +202,4 @@ DEPENDENCIES
   winrm-transport (~> 1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.10.7.depsolverfix.0

--- a/resources/chefdk/msi/localization-en-us.wxl.erb
+++ b/resources/chefdk/msi/localization-en-us.wxl.erb
@@ -28,4 +28,8 @@
   <String Id="FeatureChefDkStartMenuShortcutDescription">Install a ChefDK shortcut on the user's Start Menu.</String>
   <String Id="FeatureChefDkDesktopShortcut">Desktop Shortcut</String>
   <String Id="FeatureChefDkDesktopShortcutDescription">Install a ChefDK shortcut on the user's Desktop.</String>
+
+  <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
+  <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>
+  <String Id="FileExtractionProgress">Extracting files, please wait...</String>
 </WixLocalization>

--- a/resources/chefdk/msi/source.wxs.erb
+++ b/resources/chefdk/msi/source.wxs.erb
@@ -1,4 +1,4 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
   <!-- This is how we include wxi files -->
@@ -12,23 +12,59 @@
           Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
 
     <!--
-      Define the minimum supported installer version (2.0).
-      The install should be done for the whole machine not just the current user
+      Minimum installer version (2.0) - Window XP and above.
+      The install scope is per machine, not the current user
     -->
     <Package InstallerVersion="200" InstallPrivileges="elevated"
              Compressed="yes" InstallScope="perMachine" />
 
     <Media Id="1" Cabinet="ChefClient.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <!-- Major upgrade -->
-    <Upgrade Id="$(var.UpgradeCode)">
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VersionNumber)" IncludeMinimum="no" Property="NEWERVERSIONDETECTED" />
-      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.VersionNumber)" IncludeMaximum="no" Property="OLDERVERSIONBEINGUPGRADED" />
-    </Upgrade>
+    <!--
+      Uncomment launch condition below to check for minimum OS
+      601 = Windows 7/Server 2008R2.
+    -->
+    <!-- Condition Message="!(loc.MinimumOSVersionMessage)">
+      <![CDATA[Installed OR VersionNT >= 601]]>
+    </Condition -->
+
+    <!-- We always do Major upgrades -->
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" />
+
+    <!--
+      If fastmsi is set, custom actions will be invoked during install to unzip
+      project files, and during uninstall to remove the project folder
+    -->
+    <% if fastmsi %>
+    <SetProperty Id="FastUnzip"
+                 Value="FASTZIPDIR=[INSTALLLOCATION];FASTZIPAPPNAME=chefdk"
+                 Sequence="execute"
+                 Before="FastUnzip" />
+
+    <CustomAction Id="FastUnzip"
+                  BinaryKey="CustomActionFastMsiDLL"
+                  DllEntry="FastUnzip"
+                  Execute="deferred"
+                  Return="check" />
+
+    <Binary Id="CustomActionFastMsiDLL"
+            SourceFile="CustomActionFastMsi.CA.dll" />
+
+    <CustomAction Id="Cleanup"
+                  Directory="INSTALLLOCATION"
+                  ExeCommand="cmd /C &quot;rd /S /Q chefdk&quot;"
+                  Execute="deferred"
+                  Return="ignore" />
 
     <InstallExecuteSequence>
-      <RemoveExistingProducts After="InstallValidate" />
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
+
+    <UI>
+      <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
+    </UI>
+    <% end %>
 
     <CustomActionRef Id="WixBroadcastSettingChange" />
     <CustomActionRef Id="WixBroadcastEnvironmentChange" />


### PR DESCRIPTION
This is part 2 of the Fast MSI changes. This change depends on the following PR - see for details - 
https://github.com/chef/omnibus/pull/565

This change enables ChefDK to optionally start using the Fast MSI infra and producing zip-file including builds.

NOTE: The Fast MSI option is currently NOT enabled, so the build produced will be the regular ones for now.

@chef/omnibus-maintainers @schisamo @btm @adamedx @ksubrama @mwrock @jaym