### PR TITLE
Turn on FastMSI for ChefDK

### DIFF
--- a/config/projects/chefdk.rb
+++ b/config/projects/chefdk.rb
@@ -101,6 +101,7 @@ package :pkg do
 end
 
 package :msi do
+  fast_msi  true
   upgrade_code "AB1D6FBD-F9DC-4395-BDAD-26C4541168E7"
   signing_identity "F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09", machine_store: true
   wix_light_extension "WixUtilExtension"

--- a/resources/chefdk/msi/source.wxs.erb
+++ b/resources/chefdk/msi/source.wxs.erb
@@ -45,6 +45,7 @@
                   BinaryKey="CustomActionFastMsiDLL"
                   DllEntry="FastUnzip"
                   Execute="deferred"
+                  Impersonate="no"
                   Return="check" />
 
     <Binary Id="CustomActionFastMsiDLL"
@@ -54,6 +55,7 @@
                   Directory="INSTALLLOCATION"
                   ExeCommand="cmd /C &quot;rd /S /Q chefdk&quot;"
                   Execute="deferred"
+                  Impersonate="no"
                   Return="ignore" />
 
     <InstallExecuteSequence>


### PR DESCRIPTION
Manhattan test build of ChefDK with FastMSI looks good. 
@chef/omnibus-maintainers @schisamo @btm 