### PR TITLE
Enable Fast MSI for chef client

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -74,6 +74,7 @@ end
 compress :dmg
 
 package :msi do
+  fast_msi true
   upgrade_code "D607A85C-BDFA-4F08-83ED-2ECB4DCD6BC5"
   wix_candle_extension 'WixUtilExtension'
   signing_identity "F74E1A68005E8A9C465C3D2FF7B41F3988F0EA09", machine_store: true

--- a/resources/chef/msi/localization-en-us.wxl.erb
+++ b/resources/chef/msi/localization-en-us.wxl.erb
@@ -23,4 +23,8 @@
   <String Id="FeatureMainName"><%= friendly_name %></String>
   <String Id="FeatureServiceName"><%= friendly_name %> Service</String>
   <String Id="FeaturePSModuleName"><%= friendly_name %> PowerShell wrappers</String>
+
+  <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
+  <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>
+  <String Id="FileExtractionProgress">Extracting files, please wait...</String>
 </WixLocalization>

--- a/resources/chef/msi/source.wxs.erb
+++ b/resources/chef/msi/source.wxs.erb
@@ -20,15 +20,53 @@
 
     <Media Id="1" Cabinet="ChefClient.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <!-- Major upgrade -->
-    <Upgrade Id="$(var.UpgradeCode)">
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VersionNumber)" IncludeMinimum="no" Property="NEWERVERSIONDETECTED" />
-      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.VersionNumber)" IncludeMaximum="no" Property="OLDERVERSIONBEINGUPGRADED" MigrateFeatures="yes" />
-    </Upgrade>
+    <!--
+      Uncomment launch condition below to check for minimum OS
+      601 = Windows 7/Server 2008R2.
+    -->
+    <!-- Condition Message="!(loc.MinimumOSVersionMessage)">
+      <![CDATA[Installed OR VersionNT >= 601]]>
+    </Condition -->
+
+    <!-- We always do Major upgrades -->
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" />
+
+    <!--
+      If fastmsi is set, custom actions will be invoked during install to unzip
+      project files, and during uninstall to remove the project folder
+    -->
+    <% if fastmsi %>
+    <SetProperty Id="FastUnzip"
+                 Value="FASTZIPDIR=[INSTALLLOCATION];FASTZIPAPPNAME=chef"
+                 Sequence="execute"
+                 Before="FastUnzip" />
+
+    <CustomAction Id="FastUnzip"
+                  BinaryKey="CustomActionFastMsiDLL"
+                  DllEntry="FastUnzip"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check" />
+
+    <Binary Id="CustomActionFastMsiDLL"
+            SourceFile="CustomActionFastMsi.CA.dll" />
+
+    <CustomAction Id="Cleanup"
+                  Directory="INSTALLLOCATION"
+                  ExeCommand="cmd /C &quot;rd /S /Q chef&quot;"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore" />
 
     <InstallExecuteSequence>
-      <RemoveExistingProducts After="InstallValidate" />
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
+
+    <UI>
+      <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
+    </UI>
+    <% end %>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WindowsVolume">


### PR DESCRIPTION
This PR enables and turns on FastMSI for Chef Client.
The code is essentially the same as for Chef DK.

@chef/omnibus-maintainers @schisamo @btm 