### PR TITLE
Update API endpoint in Berksfile.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 cookbook 'omnibus'
 


### PR DESCRIPTION
While poking around I noticed this was pointing to the old Berkshelf API, so I figured we should fix that really quick. 