### PR TITLE
Let omnibus pick number of workers, except in a Solaris zone. Also enforces UTF8 encoding.

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -44,9 +44,14 @@ build_retries 3
 fetcher_retries 3
 fetcher_read_timeout 120
 
-# We limit this to 10 workers to eliminate transient timing issues in the
-# way Ruby (and other components) compiles on some more esoteric *nixes.
-workers 10
+# Work around for solaris zones, provide a less-bad number of workers
+if solaris? && Ohai['cpu']['total'] == 0
+  workers 10
+end
+
+# Some platforms do not have a UTF-8 locale, so we need to enforce one
+# or else the cacert chain will break among other things
+Encoding.default_external = Encoding::UTF_8
 
 # Load additional software
 # ------------------------------


### PR DESCRIPTION
When running in a Solaris zone with Ohai 8, the total number of
CPUs reported is 0. Instead of overriding the number of workers
globally, restrict it to just Solaris and a total CPU count of 0.

Also enables UTF8 encoding on all platforms (because some don't
by default and this breaks many things)