### PR TITLE
Point omnibus-software to update with new openssl

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 252a2a021e43368cbd838f341dd659d57aa7e417
+  revision: a7b5cbd2426c9531eccd218faa08a021da9cd502
   specs:
     omnibus-software (4.0.0)
 


### PR DESCRIPTION
Update Gemfile.lock to point to the version of omnibus-software with the latest version of openssl

@chef/omnibus-maintainers @jaym @schisamo