### PR TITLE
Pin chef and ohai

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -53,8 +53,8 @@ else
 end
 
 # Chef Release version pinning
-override :chef, version: 'master'
-override :ohai, version: 'master'
+override :chef, version: '12.6-release'
+override :ohai, version: '8.8.1'
 
 
 dependency "preparation"


### PR DESCRIPTION
Readiness for Chef 12.6.0 release

Pin chef to the release branch (12.6-release).
Pin ohai to 8.8.1

@chef/omnibus-maintainers @jaym @btm 
