### PR TITLE
Prep for release build 12.6.0

### DIFF
--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -53,8 +53,8 @@ else
 end
 
 # Chef Release version pinning
-override :chef, version: '12.6-release'
-override :ohai, version: '8.8.1'
+override :chef, version: 'master'
+override :ohai, version: 'master'
 
 
 dependency "preparation"

--- a/config/projects/chef.rb
+++ b/config/projects/chef.rb
@@ -20,7 +20,7 @@ maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 
 build_iteration 1
-build_version '12.5.1'
+build_version '12.6.0'
 
 if windows?
   # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"


### PR DESCRIPTION
Getting ready to create a release build.

The first commit bumps the version to 12.6.0.  This commit will be used to kick off the release build.

The second commit re-pins chef and ohai back to master. We do this in the same PR so that git_poll will kick off on the 2nd commit, not the first.

@chef/omnibus-maintainers @jaym @schisamo @jkeiser 
