### PR TITLE
Fix typo in project location

### DIFF
--- a/resources/chef/msi/source.wxs.erb
+++ b/resources/chef/msi/source.wxs.erb
@@ -77,7 +77,7 @@
           </Component>
         </Directory>
         <Directory Id="INSTALLLOCATION" Name="opscode">
-          <Directory Id="PROJECTLOCATION" Name="#(var.ProjectLocationDir)" >
+          <Directory Id="PROJECTLOCATION" Name="$(var.ProjectLocationDir)" >
             <Directory Id="PROJECTLOCATIONBIN" Name="bin" >
               <Component Id="ChefClientPath" Guid="{7F663F88-55A2-4E20-82BF-8BD2E60BB83A}" >
                 <Environment Id="ClientPathEnvironment"


### PR DESCRIPTION
Typo in source.wxs.erb causing installation of chef client to not work correctly.

See issue # 4306 - https://github.com/chef/chef/issues/4306

@ksubrama @jaym @chef/omnibus-maintainers 