### PR TITLE
Fix regression with postinst script

### DIFF
--- a/config/projects/angrychef.rb
+++ b/config/projects/angrychef.rb
@@ -36,7 +36,6 @@ else
 end
 
 resources_path "#{resources_path}/../chef"
-package_scripts_path "#{package_scripts_path}/../chef"
 
 msi_upgrade_code = "D7FDDC1A-7668-404E-AD2F-61F875632A9C"
 project_location_dir = "angrychef"

--- a/config/projects/chef-fips.rb
+++ b/config/projects/chef-fips.rb
@@ -39,4 +39,3 @@ project_location_dir = "chef-fips"
 
 # Use chef's scripts for everything.
 resources_path "#{resources_path}/../chef"
-package_scripts_path "#{package_scripts_path}/../chef"

--- a/jenkins/verify-chef.sh
+++ b/jenkins/verify-chef.sh
@@ -19,26 +19,17 @@ else
 fi
 export USR_BIN_DIR
 
-# sanity check that we're getting symlinks from the pre-install script
-if [ ! -L $USR_BIN_DIR/chef-client ]; then
-  echo "$USR_BIN_DIR/chef-client symlink was not installed by pre-install script!"
-  exit 1
-fi
+# sanity check that we're getting the correct symlinks from the pre-install script
+linked_binaries=( "chef-client" "knife" "chef-solo" "ohai" )
 
-if [ ! -L "$USR_BIN_DIR/knife" ]; then
-  echo "$USR_BIN_DIR/knife symlink was not installed by pre-install script!"
-  exit 1
-fi
-
-if [ ! -L "$USR_BIN_DIR/chef-solo" ]; then
-  echo "$USR_BIN_DIR/chef-solo symlink was not installed by pre-install script!"
-  exit 1
-fi
-
-if [ ! -L "$USR_BIN_DIR/ohai" ]; then
-  echo "$USR_BIN_DIR/ohai symlink was not installed by pre-install script!"
-  exit 1
-fi
+for i in "${linked_binaries[@]}"
+do
+  LINK_TARGET=`readlink $USR_BIN_DIR/$i`
+  if [ "$LINK_TARGET" != "$EMBEDDED_BIN_DIR/$i" ]; then
+    echo "$USR_BIN_DIR/$i symlink to $EMBEDDED_BIN_DIR/$i was not correctly created by the pre-install script!"
+    exit 1
+  fi
+done
 
 # Ensure the calling environment (disapproval look Bundler) does not
 # infect our Ruby environment created by the `chef-client` cli.

--- a/package-scripts/angrychef/postinst
+++ b/package-scripts/angrychef/postinst
@@ -11,7 +11,7 @@
 #
 
 PROGNAME=`basename $0`
-INSTALLER_DIR=/opt/chef
+INSTALLER_DIR=/opt/angrychef
 CONFIG_DIR=/etc/chef
 USAGE="usage: $0 [-v validation_key] ([-o organization] || [-u url])"
 

--- a/package-scripts/angrychef/postrm
+++ b/package-scripts/angrychef/postrm
@@ -1,0 +1,42 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
+is_smartos() {
+  uname -v | grep "^joyent" 2>&1 >/dev/null
+}
+
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+if is_smartos; then
+    PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
+else
+    PREFIX="/usr"
+fi
+
+cleanup_symlinks() {
+  binaries="chef-client chef-solo chef-apply chef-shell knife shef ohai"
+  for binary in $binaries; do
+    rm -f $PREFIX/bin/$binary
+  done
+}
+
+# Clean up binary symlinks if they exist
+# see: http://tickets.opscode.com/browse/CHEF-3022
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
+fi

--- a/package-scripts/chef-fips/postinst
+++ b/package-scripts/chef-fips/postinst
@@ -11,7 +11,7 @@
 #
 
 PROGNAME=`basename $0`
-INSTALLER_DIR=/opt/chef
+INSTALLER_DIR=/opt/chef-fips
 CONFIG_DIR=/etc/chef
 USAGE="usage: $0 [-v validation_key] ([-o organization] || [-u url])"
 

--- a/package-scripts/chef-fips/postrm
+++ b/package-scripts/chef-fips/postrm
@@ -1,0 +1,42 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
+is_smartos() {
+  uname -v | grep "^joyent" 2>&1 >/dev/null
+}
+
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+if is_smartos; then
+    PREFIX="/opt/local"
+elif is_darwin; then
+    PREFIX="/usr/local"
+else
+    PREFIX="/usr"
+fi
+
+cleanup_symlinks() {
+  binaries="chef-client chef-solo chef-apply chef-shell knife shef ohai"
+  for binary in $binaries; do
+    rm -f $PREFIX/bin/$binary
+  done
+}
+
+# Clean up binary symlinks if they exist
+# see: http://tickets.opscode.com/browse/CHEF-3022
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
+fi


### PR DESCRIPTION
the postinst script lacks an easy way to know what package it is part of, which makes it difficult to reuse it currently. This branch reverts the change that attempted to reuse package scripts and modifies the `verify-chef.sh` script to test symlink targets.

