### PR TITLE
ChefDK is getting cached in a subdirectory (chef-dk/chefdk)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', github: 'chef/omnibus'
+gem 'omnibus', github: 'chef/omnibus', branch: 'tball/chefdk'
 gem 'omnibus-software', github: 'chef/omnibus-software'
 
 # This development group is installed by default when you run `bundle install`,

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', github: 'chef/omnibus', branch: 'tball/chefdk'
+gem 'omnibus', github: 'chef/omnibus'
 gem 'omnibus-software', github: 'chef/omnibus-software'
 
 # This development group is installed by default when you run `bundle install`,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,8 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 58f4b2622adc524aa7bd8a369938a0ea44aaf3aa
+  revision: 75e7077d5c5cc0c42e019afd3d107708e0b0164a
+  branch: tball/chefdk
   specs:
     omnibus (5.0.0)
       aws-sdk (~> 2)
@@ -22,12 +23,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.6)
-      aws-sdk-resources (= 2.2.6)
-    aws-sdk-core (2.2.6)
+    aws-sdk (2.2.8)
+      aws-sdk-resources (= 2.2.8)
+    aws-sdk-core (2.2.8)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.6)
-      aws-sdk-core (= 2.2.6)
+    aws-sdk-resources (2.2.8)
+      aws-sdk-core (= 2.2.8)
     berkshelf (3.2.4)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -60,7 +61,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.5.1)
+    chef-config (12.6.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-sugar (3.2.0)
@@ -198,6 +199,3 @@ DEPENDENCIES
   omnibus-software!
   test-kitchen (~> 1.4.0)
   winrm-transport (~> 1.0)
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 75e7077d5c5cc0c42e019afd3d107708e0b0164a
-  branch: tball/chefdk
+  revision: f1231f74ebda76530e73fd6416e1ee7eb7be3656
   specs:
     omnibus (5.0.0)
       aws-sdk (~> 2)
@@ -23,12 +22,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.8)
-      aws-sdk-resources (= 2.2.8)
-    aws-sdk-core (2.2.8)
+    aws-sdk (2.2.9)
+      aws-sdk-resources (= 2.2.9)
+    aws-sdk-core (2.2.9)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.8)
-      aws-sdk-core (= 2.2.8)
+    aws-sdk-resources (2.2.9)
+      aws-sdk-core (= 2.2.9)
     berkshelf (3.2.4)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -85,7 +84,7 @@ GEM
     hitimes (1.2.2)
     hitimes (1.2.2-x86-mingw32)
     httpclient (2.6.0.1)
-    ipaddress (0.8.0)
+    ipaddress (0.8.2)
     jmespath (1.1.3)
     json (1.8.3)
     kitchen-vagrant (0.19.0)

--- a/config/software/chefdk.rb
+++ b/config/software/chefdk.rb
@@ -21,7 +21,6 @@ source git: "git://github.com/chef/chef-dk.git"
 
 relative_path "chef-dk"
 
-
 if windows?
   dependency "ruby-windows"
   dependency "ruby-windows-devkit"
@@ -69,7 +68,7 @@ build do
       " --verbose", env: env
 
   appbundle 'berkshelf'
-  appbundle 'chef-dk'
+  appbundle 'chefdk'
   appbundle 'chef-vault'
   appbundle 'foodcritic'
   appbundle 'rubocop'


### PR DESCRIPTION
So we need to pull in omnibus changes to respect that, and modify our appbundle call to use the correct new API

This is an attempt to fix our ChefDK master builds in Manhattan

\cc @jaym @schisamo @danielsdeleo 