### PR TITLE
Reverting https://github.com/chef/omnibus/pull/583 to try and fix ChefDK build errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: f1231f74ebda76530e73fd6416e1ee7eb7be3656
+  revision: b6422a3f9678a6f5cc145c9b0a488409ac0af73c
   specs:
     omnibus (5.0.0)
       aws-sdk (~> 2)
@@ -74,7 +74,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     ffi (1.9.10-x86-mingw32)
-    ffi-yajl (2.2.2)
+    ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
@@ -198,3 +198,6 @@ DEPENDENCIES
   omnibus-software!
   test-kitchen (~> 1.4.0)
   winrm-transport (~> 1.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
\cc @jaym @danielsdeleo @schisamo @ksubrama 

This simply uses the changes from https://github.com/chef/omnibus/pull/599.  Before committing I will rebase this to use master once 599 is merged.

The goal of this change is to fix Windows builds in Manhattan.